### PR TITLE
convert url param for lookup to lowercase

### DIFF
--- a/queries/queries.go
+++ b/queries/queries.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -426,6 +427,10 @@ type issueOrPullRequest struct {
 
 // IssueOrPullRequestID returns the ID of the issue or pull request from a URL.
 func IssueOrPullRequestID(client api.GQLClient, rawURL string) (string, error) {
+	// https://docs.github.com/en/graphql/reference/queries#resource
+	// will not find the resource if the case isn't all lower, for example
+	// GitHub vs github.
+	rawURL = strings.ToLower(rawURL)
 	uri, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Fixes https://github.com/github/gh-projects/issues/49

This is a limitation of the resource lookup api https://docs.github.com/en/graphql/reference/queries#resource, which will not find the resource if the case isn't all lower, for example GitHub vs github. Converting to lowercase seems like a good fix for users.

If this causes issues where mixed case urls are not found, I'll switch to instead be more explicit in the error shown to the user.
