### PR TITLE
serialize items to json

### DIFF
--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -83,7 +83,7 @@ gh projects item-list 1 --org github
 
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
-	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be one of 'json' or 'csv'.")
+	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
 	listCmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to get. Defaults to 100.")
 
 	// owner can be a user or an org
@@ -93,8 +93,8 @@ gh projects item-list 1 --org github
 }
 
 func runList(config listConfig) error {
-	if config.opts.format != "" && config.opts.format != "csv" && config.opts.format != "json" {
-		return fmt.Errorf("format must be one of 'json' or 'csv'")
+	if config.opts.format != "" && config.opts.format != "json" {
+		return fmt.Errorf("format must be 'json'")
 	}
 
 	owner, err := queries.NewOwner(config.client, config.opts.userOwner, config.opts.orgOwner)

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -166,7 +166,7 @@ func serialize(project queries.Project) []map[string]any {
 		o["content"] = i.Data()
 		for _, v := range i.FieldValues.Nodes {
 			id := v.ID()
-			value := v.Value()
+			value := v.Data()
 
 			o[fields[id]] = value
 		}

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -162,6 +162,8 @@ func serialize(project queries.Project) []map[string]any {
 	// and set the value to the field value
 	for _, i := range project.Items.Nodes {
 		o := make(map[string]any)
+		o["id"] = i.Id
+		o["content"] = i.Data()
 		for _, v := range i.FieldValues.Nodes {
 			id := v.ID()
 			value := v.Value()

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -148,69 +148,25 @@ func printResults(config listConfig, items []queries.ProjectItem, login string) 
 	return config.tp.Render()
 }
 
+// serialize creates a map from field to field values
 func serialize(project queries.Project) []map[string]any {
 	fields := make(map[string]string)
 
+	// make a map of fields by ID
 	for _, f := range project.Fields.Nodes {
 		fields[f.ID()] = f.Name()
 	}
 	itemsSlice := make([]map[string]any, 0)
+
+	// for each value, look up the name by ID
+	// and set the value to the field value
 	for _, i := range project.Items.Nodes {
 		o := make(map[string]any)
 		for _, v := range i.FieldValues.Nodes {
-			// name and value based on type
-			switch v.Type {
-			case "ProjectV2ItemFieldDateValue":
-				o[fields[v.ProjectV2ItemFieldDateValue.Field.ID()]] = v.ProjectV2ItemFieldDateValue.Date
-			case "ProjectV2ItemFieldIterationValue":
-				o[fields[v.ProjectV2ItemFieldIterationValue.Field.ID()]] = v.ProjectV2ItemFieldIterationValue.StartDate // what about duration
-			case "ProjectV2ItemFieldNumberValue":
-				o[fields[v.ProjectV2ItemFieldNumberValue.Field.ID()]] = fmt.Sprintf("%f", v.ProjectV2ItemFieldNumberValue.Number)
-			case "ProjectV2ItemFieldSingleSelectValue":
-				o[fields[v.ProjectV2ItemFieldSingleSelectValue.Field.ID()]] = v.ProjectV2ItemFieldSingleSelectValue.Name
-			case "ProjectV2ItemFieldTextValue":
-				o[fields[v.ProjectV2ItemFieldTextValue.Field.ID()]] = v.ProjectV2ItemFieldTextValue.Text
-			case "ProjectV2ItemFieldMilestoneValue":
-				o[fields[v.ProjectV2ItemFieldMilestoneValue.Field.ID()]] = struct {
-					Description string
-					DueOn       string
-				}{
-					Description: v.ProjectV2ItemFieldMilestoneValue.Milestone.Description,
-					DueOn:       v.ProjectV2ItemFieldMilestoneValue.Milestone.DueOn,
-				}
-			case "ProjectV2ItemFieldLabelValue":
-				name := make([]string, 0)
-				for _, p := range v.ProjectV2ItemFieldLabelValue.Labels.Nodes {
-					name = append(name, p.Name)
-				}
-				o[fields[v.ProjectV2ItemFieldLabelValue.Field.ID()]] = name
+			id := v.ID()
+			value := v.Value()
 
-			case "ProjectV2ItemFieldPullRequestValue":
-				urls := make([]string, 0)
-				for _, p := range v.ProjectV2ItemFieldPullRequestValue.PullRequests.Nodes {
-					urls = append(urls, p.Url)
-				}
-				o[fields[v.ProjectV2ItemFieldPullRequestValue.Field.ID()]] = urls
-			case "ProjectV2ItemFieldRepositoryValue":
-				o[fields[v.ProjectV2ItemFieldRepositoryValue.Field.ID()]] = v.ProjectV2ItemFieldRepositoryValue.Repository.Url
-			case "ProjectV2ItemFieldUserValue":
-				logins := make([]string, 0)
-				for _, p := range v.ProjectV2ItemFieldUserValue.Users.Nodes {
-					logins = append(logins, p.Login)
-				}
-				o[fields[v.ProjectV2ItemFieldUserValue.Field.ID()]] = logins
-			case "ProjectV2ItemFieldReviewerValue":
-				names := make([]string, 0)
-				for _, p := range v.ProjectV2ItemFieldReviewerValue.Reviewers.Nodes {
-					if p.Type == "Team" {
-						names = append(names, p.Team.Name)
-					} else if p.Type == "User" {
-						names = append(names, p.User.Login)
-					}
-				}
-				o[fields[v.ProjectV2ItemFieldReviewerValue.Field.ID()]] = names
-
-			}
+			o[fields[id]] = value
 		}
 		itemsSlice = append(itemsSlice, o)
 	}

--- a/cmd/item-list/item_list_test.go
+++ b/cmd/item-list/item_list_test.go
@@ -344,8 +344,10 @@ func TestRunList_JSON(t *testing.T) {
 									"type": "ISSUE",
 									"id":   "issue ID",
 									"content": map[string]interface{}{
-										"title":  "an issue",
-										"number": 1,
+										"__typename": "Issue",
+										"title":      "an issue",
+										"body":       "an issue body",
+										"number":     1,
 										"repository": map[string]string{
 											"nameWithOwner": "cli/go-gh",
 										},
@@ -355,8 +357,10 @@ func TestRunList_JSON(t *testing.T) {
 									"type": "PULL_REQUEST",
 									"id":   "pull request ID",
 									"content": map[string]interface{}{
-										"title":  "a pull request",
-										"number": 2,
+										"__typename": "PullRequest",
+										"title":      "a pull request",
+										"body":       "a pull request body",
+										"number":     2,
 										"repository": map[string]string{
 											"nameWithOwner": "cli/go-gh",
 										},
@@ -366,7 +370,9 @@ func TestRunList_JSON(t *testing.T) {
 									"type": "DRAFT_ISSUE",
 									"id":   "draft issue ID",
 									"content": map[string]interface{}{
-										"title": "draft issue",
+										"__typename": "Issue",
+										"title":      "draft issue",
+										"body":       "draft issue body",
 									},
 								},
 							},
@@ -394,7 +400,7 @@ func TestRunList_JSON(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		"[{\"content\":null,\"id\":\"issue ID\"},{\"content\":null,\"id\":\"pull request ID\"},{\"content\":null,\"id\":\"draft issue ID\"}]\n",
+		"[{\"content\":{\"TypeName\":\"Issue\",\"Body\":\"an issue body\",\"Title\":\"an issue\",\"Number\":1,\"Repository\":\"cli/go-gh\"},\"id\":\"issue ID\"},{\"content\":{\"TypeName\":\"PullRequest\",\"Body\":\"a pull request body\",\"Title\":\"a pull request\",\"Number\":2,\"Repository\":\"cli/go-gh\"},\"id\":\"pull request ID\"},{\"content\":{\"TypeName\":\"Issue\",\"Body\":\"draft issue body\",\"Title\":\"draft issue\",\"Number\":0,\"Repository\":\"\"},\"id\":\"draft issue ID\"}]\n",
 		buf.String())
 }
 

--- a/cmd/item-list/item_list_test.go
+++ b/cmd/item-list/item_list_test.go
@@ -42,6 +42,7 @@ func TestRunList_User(t *testing.T) {
 				"first":  100,
 				"login":  "monalisa",
 				"number": 1,
+				"after":  nil,
 			},
 		}).
 		Reply(200).
@@ -139,6 +140,7 @@ func TestRunList_Org(t *testing.T) {
 				"first":  100,
 				"login":  "github",
 				"number": 1,
+				"after":  nil,
 			},
 		}).
 		Reply(200).
@@ -233,6 +235,7 @@ func TestRunList_Me(t *testing.T) {
 			"variables": map[string]interface{}{
 				"first":  100,
 				"number": 1,
+				"after":  nil,
 			},
 		}).
 		Reply(200).
@@ -299,6 +302,102 @@ func TestRunList_Me(t *testing.T) {
 		buf.String())
 }
 
+func TestRunList_JSON(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// get viewer ID
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		MatchType("json").
+		JSON(map[string]interface{}{
+			"query": "query ViewerLogin.*",
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"viewer": map[string]interface{}{
+					"id": "an ID",
+				},
+			},
+		})
+
+	// list project items
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query ViewerProjectWithItems.*",
+			"variables": map[string]interface{}{
+				"first":  100,
+				"number": 1,
+				"after":  nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"viewer": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"items": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"type": "ISSUE",
+									"id":   "issue ID",
+									"content": map[string]interface{}{
+										"title":  "an issue",
+										"number": 1,
+										"repository": map[string]string{
+											"nameWithOwner": "cli/go-gh",
+										},
+									},
+								},
+								{
+									"type": "PULL_REQUEST",
+									"id":   "pull request ID",
+									"content": map[string]interface{}{
+										"title":  "a pull request",
+										"number": 2,
+										"repository": map[string]string{
+											"nameWithOwner": "cli/go-gh",
+										},
+									},
+								},
+								{
+									"type": "DRAFT_ISSUE",
+									"id":   "draft issue ID",
+									"content": map[string]interface{}{
+										"title": "draft issue",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := listConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: listOpts{
+			number:    1,
+			userOwner: "@me",
+			format:    "json",
+		},
+		client: client,
+	}
+
+	err = runList(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"[{\"content\":null,\"id\":\"issue ID\"},{\"content\":null,\"id\":\"pull request ID\"},{\"content\":null,\"id\":\"draft issue ID\"}]\n",
+		buf.String())
+}
+
 func TestRunList_Empty(t *testing.T) {
 	defer gock.Off()
 	gock.Observe(gock.DumpRequest)
@@ -326,6 +425,7 @@ func TestRunList_Empty(t *testing.T) {
 			"variables": map[string]interface{}{
 				"first":  100,
 				"number": 1,
+				"after":  nil,
 			},
 		}).
 		Reply(200).

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -75,7 +75,7 @@ type ProjectItem struct {
 	TypeName    string `graphql:"type"`
 	FieldValues struct {
 		Nodes []FieldValueNodes
-	} `graphql:"fieldValues(first: 100)"`
+	} `graphql:"fieldValues(first: 100)"` // hardcoded to 100 for now on the assumption that this is a reasonable limit
 }
 
 func (p ProjectItem) Data() any {
@@ -139,7 +139,7 @@ type FieldValueNodes struct {
 			Nodes []struct {
 				Name string
 			}
-		} `graphql:"labels(first: 10)"`
+		} `graphql:"labels(first: 10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldLabelValue"`
 	ProjectV2ItemFieldNumberValue struct {
@@ -166,7 +166,7 @@ type FieldValueNodes struct {
 			Nodes []struct {
 				Url string
 			}
-		} `graphql:"pullRequests(first:10)"`
+		} `graphql:"pullRequests(first:10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldPullRequestValue"`
 	ProjectV2ItemFieldRepositoryValue struct {
@@ -180,7 +180,7 @@ type FieldValueNodes struct {
 			Nodes []struct {
 				Login string
 			}
-		} `graphql:"users(first: 10)"`
+		} `graphql:"users(first: 10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldUserValue"`
 	ProjectV2ItemFieldReviewerValue struct {
@@ -411,7 +411,7 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, first int) (Projec
 		if !hasNext {
 			break
 		}
-
+		// set the cursor to the end of the last page
 		variables["after"] = (*githubv4.String)(&cursor)
 		if o.Type == UserOwner {
 			variables["login"] = graphql.String(o.Login)

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -65,6 +65,7 @@ type Project struct {
 // ProjectItem is a ProjectV2Item GraphQL object https://docs.github.com/en/graphql/reference/objects#projectv2item.
 type ProjectItem struct {
 	Content struct {
+		TypeName    string      `graphql:"__typename"`
 		DraftIssue  DraftIssue  `graphql:"... on DraftIssue"`
 		PullRequest PullRequest `graphql:"... on PullRequest"`
 		Issue       Issue       `graphql:"... on Issue"`
@@ -74,6 +75,51 @@ type ProjectItem struct {
 	FieldValues struct {
 		Nodes []FieldValueNodes
 	} `graphql:"fieldValues(first: 100)"`
+}
+
+func (p ProjectItem) Data() any {
+	switch p.Content.TypeName {
+	case "DraftIssue":
+		return struct {
+			TypeName string
+			Body     string
+			Title    string
+		}{
+			TypeName: p.Content.TypeName,
+			Body:     p.Content.DraftIssue.Body,
+			Title:    p.Content.DraftIssue.Title,
+		}
+	case "Issue":
+		return struct {
+			TypeName   string
+			Body       string
+			Title      string
+			Number     int
+			Repository string
+		}{
+			TypeName:   p.Content.TypeName,
+			Body:       p.Content.Issue.Body,
+			Title:      p.Content.Issue.Title,
+			Number:     p.Content.Issue.Number,
+			Repository: p.Content.Issue.Repository.NameWithOwner,
+		}
+	case "PullRequest":
+		return struct {
+			TypeName   string
+			Body       string
+			Title      string
+			Number     int
+			Repository string
+		}{
+			TypeName:   p.Content.TypeName,
+			Body:       p.Content.PullRequest.Body,
+			Title:      p.Content.PullRequest.Title,
+			Number:     p.Content.PullRequest.Number,
+			Repository: p.Content.PullRequest.Repository.NameWithOwner,
+		}
+	}
+
+	return nil
 }
 
 type FieldValueNodes struct {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -227,7 +227,7 @@ func (v FieldValueNodes) ID() string {
 	return ""
 }
 
-func (v FieldValueNodes) Value() any {
+func (v FieldValueNodes) Data() any {
 	switch v.Type {
 	case "ProjectV2ItemFieldDateValue":
 		return v.ProjectV2ItemFieldDateValue.Date

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -72,82 +72,175 @@ type ProjectItem struct {
 	Id          string
 	TypeName    string `graphql:"type"`
 	FieldValues struct {
-		Nodes []struct {
-			Type                        string `graphql:"__typename"`
-			ProjectV2ItemFieldDateValue struct {
-				Date  string
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldDateValue"`
-			ProjectV2ItemFieldIterationValue struct {
-				StartDate string
-				Duration  int
-				Field     ProjectField
-			} `graphql:"... on ProjectV2ItemFieldIterationValue"`
-			ProjectV2ItemFieldLabelValue struct {
-				Labels struct {
-					Nodes []struct {
-						Name string
-					}
-				} `graphql:"labels(first: 10)"`
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldLabelValue"`
-			ProjectV2ItemFieldNumberValue struct {
-				Number float32
-				Field  ProjectField
-			} `graphql:"... on ProjectV2ItemFieldNumberValue"`
-			ProjectV2ItemFieldSingleSelectValue struct {
-				Name  string
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
-			ProjectV2ItemFieldTextValue struct {
-				Text  string
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldTextValue"`
-			ProjectV2ItemFieldMilestoneValue struct {
-				Milestone struct {
-					Description string
-					DueOn       string
-				}
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldMilestoneValue"`
-			ProjectV2ItemFieldPullRequestValue struct {
-				PullRequests struct {
-					Nodes []struct {
-						Url string
-					}
-				} `graphql:"pullRequests(first:10)"`
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldPullRequestValue"`
-			ProjectV2ItemFieldRepositoryValue struct {
-				Repository struct {
-					Url string
-				}
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldRepositoryValue"`
-			ProjectV2ItemFieldUserValue struct {
-				Users struct {
-					Nodes []struct {
-						Login string
-					}
-				} `graphql:"users(first: 10)"`
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldUserValue"`
-			ProjectV2ItemFieldReviewerValue struct {
-				Reviewers struct {
-					Nodes []struct {
-						Type string `graphql:"__typename"`
-						Team struct {
-							Name string
-						} `graphql:"... on Team"`
-						User struct {
-							Login string
-						} `graphql:"... on User"`
-					}
-				}
-				Field ProjectField
-			} `graphql:"... on ProjectV2ItemFieldReviewerValue"`
-		}
+		Nodes []FieldValueNodes
 	} `graphql:"fieldValues(first: 100)"`
+}
+
+type FieldValueNodes struct {
+	Type                        string `graphql:"__typename"`
+	ProjectV2ItemFieldDateValue struct {
+		Date  string
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldDateValue"`
+	ProjectV2ItemFieldIterationValue struct {
+		StartDate string
+		Duration  int
+		Field     ProjectField
+	} `graphql:"... on ProjectV2ItemFieldIterationValue"`
+	ProjectV2ItemFieldLabelValue struct {
+		Labels struct {
+			Nodes []struct {
+				Name string
+			}
+		} `graphql:"labels(first: 10)"`
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldLabelValue"`
+	ProjectV2ItemFieldNumberValue struct {
+		Number float32
+		Field  ProjectField
+	} `graphql:"... on ProjectV2ItemFieldNumberValue"`
+	ProjectV2ItemFieldSingleSelectValue struct {
+		Name  string
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldSingleSelectValue"`
+	ProjectV2ItemFieldTextValue struct {
+		Text  string
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldTextValue"`
+	ProjectV2ItemFieldMilestoneValue struct {
+		Milestone struct {
+			Description string
+			DueOn       string
+		}
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldMilestoneValue"`
+	ProjectV2ItemFieldPullRequestValue struct {
+		PullRequests struct {
+			Nodes []struct {
+				Url string
+			}
+		} `graphql:"pullRequests(first:10)"`
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldPullRequestValue"`
+	ProjectV2ItemFieldRepositoryValue struct {
+		Repository struct {
+			Url string
+		}
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldRepositoryValue"`
+	ProjectV2ItemFieldUserValue struct {
+		Users struct {
+			Nodes []struct {
+				Login string
+			}
+		} `graphql:"users(first: 10)"`
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldUserValue"`
+	ProjectV2ItemFieldReviewerValue struct {
+		Reviewers struct {
+			Nodes []struct {
+				Type string `graphql:"__typename"`
+				Team struct {
+					Name string
+				} `graphql:"... on Team"`
+				User struct {
+					Login string
+				} `graphql:"... on User"`
+			}
+		}
+		Field ProjectField
+	} `graphql:"... on ProjectV2ItemFieldReviewerValue"`
+}
+
+func (v FieldValueNodes) ID() string {
+	switch v.Type {
+	case "ProjectV2ItemFieldDateValue":
+		return v.ProjectV2ItemFieldDateValue.Field.ID()
+	case "ProjectV2ItemFieldIterationValue":
+		return v.ProjectV2ItemFieldIterationValue.Field.ID()
+	case "ProjectV2ItemFieldNumberValue":
+		return v.ProjectV2ItemFieldNumberValue.Field.ID()
+	case "ProjectV2ItemFieldSingleSelectValue":
+		return v.ProjectV2ItemFieldSingleSelectValue.Field.ID()
+	case "ProjectV2ItemFieldTextValue":
+		return v.ProjectV2ItemFieldTextValue.Field.ID()
+	case "ProjectV2ItemFieldMilestoneValue":
+		return v.ProjectV2ItemFieldMilestoneValue.Field.ID()
+	case "ProjectV2ItemFieldLabelValue":
+		return v.ProjectV2ItemFieldLabelValue.Field.ID()
+	case "ProjectV2ItemFieldPullRequestValue":
+		return v.ProjectV2ItemFieldPullRequestValue.Field.ID()
+	case "ProjectV2ItemFieldRepositoryValue":
+		return v.ProjectV2ItemFieldRepositoryValue.Field.ID()
+	case "ProjectV2ItemFieldUserValue":
+		return v.ProjectV2ItemFieldUserValue.Field.ID()
+	case "ProjectV2ItemFieldReviewerValue":
+		return v.ProjectV2ItemFieldReviewerValue.Field.ID()
+	}
+
+	return ""
+}
+
+func (v FieldValueNodes) Value() any {
+	switch v.Type {
+	case "ProjectV2ItemFieldDateValue":
+		return v.ProjectV2ItemFieldDateValue.Date
+	case "ProjectV2ItemFieldIterationValue":
+		return struct {
+			StartDate string
+			Duration  int
+		}{
+			StartDate: v.ProjectV2ItemFieldIterationValue.StartDate,
+			Duration:  v.ProjectV2ItemFieldIterationValue.Duration,
+		}
+	case "ProjectV2ItemFieldNumberValue":
+		return v.ProjectV2ItemFieldNumberValue.Number
+	case "ProjectV2ItemFieldSingleSelectValue":
+		return v.ProjectV2ItemFieldSingleSelectValue.Name
+	case "ProjectV2ItemFieldTextValue":
+		return v.ProjectV2ItemFieldTextValue.Text
+	case "ProjectV2ItemFieldMilestoneValue":
+		return struct {
+			Description string
+			DueOn       string
+		}{
+			Description: v.ProjectV2ItemFieldMilestoneValue.Milestone.Description,
+			DueOn:       v.ProjectV2ItemFieldMilestoneValue.Milestone.DueOn,
+		}
+	case "ProjectV2ItemFieldLabelValue":
+		names := make([]string, 0)
+		for _, p := range v.ProjectV2ItemFieldLabelValue.Labels.Nodes {
+			names = append(names, p.Name)
+		}
+		return names
+	case "ProjectV2ItemFieldPullRequestValue":
+		urls := make([]string, 0)
+		for _, p := range v.ProjectV2ItemFieldPullRequestValue.PullRequests.Nodes {
+			urls = append(urls, p.Url)
+		}
+		return urls
+	case "ProjectV2ItemFieldRepositoryValue":
+		return v.ProjectV2ItemFieldRepositoryValue.Repository.Url
+	case "ProjectV2ItemFieldUserValue":
+		logins := make([]string, 0)
+		for _, p := range v.ProjectV2ItemFieldUserValue.Users.Nodes {
+			logins = append(logins, p.Login)
+		}
+		return logins
+	case "ProjectV2ItemFieldReviewerValue":
+		names := make([]string, 0)
+		for _, p := range v.ProjectV2ItemFieldReviewerValue.Reviewers.Nodes {
+			if p.Type == "Team" {
+				names = append(names, p.Team.Name)
+			} else if p.Type == "User" {
+				names = append(names, p.User.Login)
+			}
+		}
+		return names
+
+	}
+
+	return nil
 }
 
 type DraftIssue struct {


### PR DESCRIPTION
Closes https://github.com/github/gh-projects/issues/46

Adds JSON formatting as an option to the items-list command, as well as pagination. I also changed the object fields, such as Item, that were inheriting $first to be hardcoded to the API limit of 100.

This ends up fetching more data that may not be used if the format isn't JSON, but it seems like a reasonable tradeoff at the moment.

I plan to add more tests, and possibly the option to output to csv as well, in the future.