### PR TITLE
Revert "convert url param for lookup to lowercase"

### DIFF
--- a/cmd/item-add/item_add.go
+++ b/cmd/item-add/item_add.go
@@ -82,7 +82,7 @@ gh projects item-add 1 --org github --url https://github.com/cli/go-gh/issues/1
 
 	addItemCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	addItemCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
-	addItemCmd.Flags().StringVar(&opts.itemURL, "url", "", "URL of the issue or pull request to add to the project. Must be of form https://github.com/OWNER/REPO/issues/NUMBER or https://github.com/OWNER/REPO/pull/NUMBER")
+	addItemCmd.Flags().StringVar(&opts.itemURL, "url", "", "URL of the issue or pull request to add to the project. Note that the name of the owner is case sensitive, and will fail to find the item if it does not match. Must be of form https://github.com/OWNER/REPO/issues/NUMBER or https://github.com/OWNER/REPO/pull/NUMBER")
 	addItemCmd.MarkFlagsMutuallyExclusive("user", "org")
 
 	_ = addItemCmd.MarkFlagRequired("url")

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -709,7 +709,7 @@ func IssueOrPullRequestID(client api.GQLClient, rawURL string) (string, error) {
 	} else if query.Resource.Typename == "PullRequest" {
 		return query.Resource.PullRequest.ID, nil
 	}
-	return "", errors.New("unknown resource type")
+	return "", errors.New("resource not found, please check the URL")
 }
 
 // userProjects queries the $first projects of a user.

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 	"time"
 
 	"github.com/AlecAivazis/survey/v2"
@@ -693,10 +692,6 @@ type issueOrPullRequest struct {
 
 // IssueOrPullRequestID returns the ID of the issue or pull request from a URL.
 func IssueOrPullRequestID(client api.GQLClient, rawURL string) (string, error) {
-	// https://docs.github.com/en/graphql/reference/queries#resource
-	// will not find the resource if the case isn't all lower, for example
-	// GitHub vs github.
-	rawURL = strings.ToLower(rawURL)
 	uri, err := url.Parse(rawURL)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Reverts github/gh-projects#55

the resource lookup fail if the api expects it to be mixed case, so this limits users who can't use all lower case