### PR TITLE
add $first boundary when fetching item reviewers

### DIFF
--- a/queries/queries.go
+++ b/queries/queries.go
@@ -220,7 +220,7 @@ type FieldValueNodes struct {
 					Login string
 				} `graphql:"... on User"`
 			}
-		}
+		} `graphql:"reviewers(first: 10)"` // experienced issues with larger limits, 10 seems like enough for now
 		Field ProjectField
 	} `graphql:"... on ProjectV2ItemFieldReviewerValue"`
 }


### PR DESCRIPTION
all connections require a boundary, I missed the reviewers one