### PR TITLE
remove limit on item-list and improve docs

### DIFF
--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -42,7 +42,7 @@ func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.C
 		Use:   "item-list [number]",
 		Example: `
 The default output is a column format with a subset of system defined fields.
-To list all of the fields, use the --format flag.
+To list all of the fields, use the --format directive.
 
 # list the items in the current users's project number 1
 gh projects item-list 1 --user "@me"

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -38,9 +38,12 @@ func (opts *listOpts) first() int {
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
 	opts := listOpts{}
 	listCmd := &cobra.Command{
-		Short: "List the items in a project",
+		Short: "List all of the items in a project",
 		Use:   "item-list [number]",
 		Example: `
+The default output is a column format with a subset of system defined fields.
+To list all of the fields, use the --format flag.
+
 # list the items in the current users's project number 1
 gh projects item-list 1 --user "@me"
 
@@ -49,6 +52,9 @@ gh projects item-list 1 --user monalisa
 
 # list the items in org github's project number 1
 gh projects item-list 1 --org github
+
+# list the items in org github's project number 1 in JSON format
+gh projects item-list 1 --org github --format json
 `,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -84,7 +90,6 @@ gh projects item-list 1 --org github
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-	listCmd.Flags().IntVar(&opts.limit, "limit", 0, "Maximum number of items to get. Defaults to 100.")
 
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")


### PR DESCRIPTION
Closes #67

There is a bug in https://github.com/github/gh-projects/blob/81ba6fb07bc4292cbfc5f5e1191fe4276db73b13/queries/queries.go#L436 where it should respect the limit if it has fetched enough items, but instead always paginates. Rather than setting a hardcoded number for the `first` argument and refactoring, I prefer to keep it as a configuration option for batch size, albeit not configureable by the user at the moment since I'm removing the command line flag for `--limit`.