### PR TITLE
support '@me' in list

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -114,8 +114,13 @@ func runList(config listConfig) error {
 	var login string
 	var ownerType queries.OwnerType
 	if config.opts.userOwner != "" {
-		login = config.opts.userOwner
-		ownerType = queries.UserOwner
+		if config.opts.userOwner == "@me" {
+			login = "me"
+			ownerType = queries.ViewerOwner
+		} else {
+			login = config.opts.userOwner
+			ownerType = queries.UserOwner
+		}
 	} else if config.opts.orgOwner != "" {
 		login = config.opts.orgOwner
 		ownerType = queries.OrgOwner

--- a/cmd/list/list_test.go
+++ b/cmd/list/list_test.go
@@ -111,6 +111,48 @@ func TestRunList(t *testing.T) {
 		buf.String())
 }
 
+func TestRunList_Me(t *testing.T) {
+	defer gock.Off()
+
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		Reply(200).
+		JSON(`
+			{"data":
+				{"viewer":
+					{
+						"login":"monalisa",
+						"projectsV2": {
+							"nodes": [
+								{"title": "Project 1", "shortDescription": "Short description 1", "url": "url1", "closed": false, "ID": "1"},
+								{"title": "Project 2", "shortDescription": "", "url": "url2", "closed": true, "ID": "2"}
+							]
+						}
+					}
+				}
+			}
+		`)
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := listConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: listOpts{
+			userOwner: "@me",
+		},
+		client: client,
+	}
+
+	err = runList(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Title\tDescription\tURL\tID\nProject 1\tShort description 1\turl1\t1\n",
+		buf.String())
+}
+
 func TestRunListViewer(t *testing.T) {
 	defer gock.Off()
 

--- a/integration_tests.sh
+++ b/integration_tests.sh
@@ -78,6 +78,7 @@ PROJECT_NUMBER=$(./gh-projects create --user "@me" --title clitest --format=json
 ./gh-projects view $PROJECT_NUMBER --user "@me" --format=json  | jq .
 
 ./gh-projects list --format=json  | jq .
+./gh-projects list --user="@me" --format=json  | jq .
 
 COPY_PROJECT_NUMBER=$(./gh-projects copy $PROJECT_NUMBER --source-user "@me" --target-user "@me" --title new-copy --format=json | jq '.number')
 ./gh-projects delete $COPY_PROJECT_NUMBER --user "@me" --format=json  | jq .


### PR DESCRIPTION
In testing I realized that I hadn't implemented `--user=@me` in list, because the default was to take the current user as the viewer. This is fine, except if the user does provide this value they get an error, and have to figure out why this command is different from all the others that accept a `--user` argument.

Adding support here to default to viewer with `--user=@me`