### PR TITLE
prompt for project on field-list and item-list

### DIFF
--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -52,16 +52,18 @@ gh projects field-list 1 --org github --limit 30
 
 # add --format=json to output in JSON format
 `,
-		Args: cobra.ExactArgs(1),
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			client, err := queries.NewClient()
 			if err != nil {
 				return err
 			}
 
-			opts.number, err = strconv.Atoi(args[0])
-			if err != nil {
-				return err
+			if len(args) == 1 {
+				opts.number, err = strconv.Atoi(args[0])
+				if err != nil {
+					return err
+				}
 			}
 
 			terminal := term.FromEnv()
@@ -99,6 +101,14 @@ func runList(config listConfig) error {
 	owner, err := queries.NewOwner(config.client, config.opts.userOwner, config.opts.orgOwner)
 	if err != nil {
 		return err
+	}
+
+	if config.opts.number == 0 {
+		project, err := queries.NewProject(config.client, owner, config.opts.number)
+		if err != nil {
+			return err
+		}
+		config.opts.number = project.Number
 	}
 
 	project, err := queries.ProjectFields(config.client, owner, config.opts.number, config.opts.first())

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -106,6 +106,14 @@ func runList(config listConfig) error {
 		return err
 	}
 
+	if config.opts.number == 0 {
+		project, err := queries.NewProject(config.client, owner, config.opts.number)
+		if err != nil {
+			return err
+		}
+		config.opts.number = project.Number
+	}
+
 	project, err := queries.ProjectItems(config.client, owner, config.opts.number, config.opts.first())
 	if err != nil {
 		return err


### PR DESCRIPTION
Closes #62
`field-list` and `item-list` require a project number argument, which differs from all other commands where the user is shown the interactive prompt.

This will result in a extra API call, but is a much nicer and clearer experience than the errors messages
- `accepts 1 arg(s), received 0`
- `Message: Could not resolve to a ProjectV2 with the number 0., Locations: [{Line:1 Column:100}]`
respectively.