### PR TITLE
projects query filter

### DIFF
--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -21,6 +21,7 @@ type listOpts struct {
 	orgOwner  string
 	closed    bool
 	format    string
+	query     string
 }
 
 type listConfig struct {
@@ -87,6 +88,7 @@ gh projects list --org github --closed
 	listCmd.Flags().BoolVarP(&opts.closed, "closed", "c", false, "Show closed projects.")
 	listCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open projects list in the browser.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
+	listCmd.Flags().StringVar(&opts.query, "query", "", "Query to filter projects. (e.g. 'is:closed')")
 
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")
@@ -129,7 +131,7 @@ func runList(config listConfig) error {
 		ownerType = queries.ViewerOwner
 	}
 
-	projects, err := queries.ProjectsLimit(config.client, login, ownerType, config.opts.first())
+	projects, err := queries.ProjectsLimit(config.client, login, ownerType, config.opts.first(), config.opts.query)
 	if err != nil {
 		return err
 	}

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -729,7 +729,7 @@ type userProjects struct {
 		Projects struct {
 			PageInfo PageInfo
 			Nodes    []Project
-		} `graphql:"projectsV2(first: $first, after: $after)"`
+		} `graphql:"projectsV2(first: $first, after: $after, query: $query)"`
 		Login string
 	} `graphql:"user(login: $login)"`
 }
@@ -740,7 +740,7 @@ type orgProjects struct {
 		Projects struct {
 			PageInfo PageInfo
 			Nodes    []Project
-		} `graphql:"projectsV2(first: $first, after: $after)"`
+		} `graphql:"projectsV2(first: $first, after: $after, query: $query)"`
 		Login string
 	} `graphql:"organization(login: $login)"`
 }
@@ -751,7 +751,7 @@ type viewerProjects struct {
 		Projects struct {
 			PageInfo PageInfo
 			Nodes    []Project
-		} `graphql:"projectsV2(first: $first, after: $after)"`
+		} `graphql:"projectsV2(first: $first, after: $after, query: $query)"`
 		Login string
 	} `graphql:"viewer"`
 }
@@ -974,11 +974,12 @@ func NewProject(client api.GQLClient, o *Owner, number int) (*Project, error) {
 }
 
 // ProjectsLimit returns up to limit projects for an Owner. If the OwnerType is VIEWER, no login is required.
-func ProjectsLimit(client api.GQLClient, login string, t OwnerType, limit int) ([]Project, error) {
+func ProjectsLimit(client api.GQLClient, login string, t OwnerType, limit int, query string) ([]Project, error) {
 	variables := map[string]interface{}{
 		"login": graphql.String(login),
 		"first": graphql.Int(limit),
 		"after": (*graphql.String)(nil),
+		"query": graphql.String(query),
 	}
 
 	if t == UserOwner {
@@ -1016,6 +1017,7 @@ func Projects(client api.GQLClient, login string, t OwnerType) ([]Project, error
 				"login": graphql.String(login),
 				"first": graphql.Int(100),
 				"after": cursor,
+				"query": graphql.String(""),
 			}
 			if err := doQuery(client, "UserProjects", &query, variables); err != nil {
 				return projects, err


### PR DESCRIPTION
Adds a `query` parameter to the `list` command, to filter projects on the server. This is an argument to the `projectsV2` field on the owner, for example https://docs.github.com/en/graphql/reference/objects#user

This was suggested in https://github.com/github/gh-projects/issues/76#issuecomment-1469300135 by @NMSAzulX

While it doesn't appear to break anything, I have some reservations about adding this at the moment:
- at present `list` is limited to 100 results, and I'm not sure if the query is applied before or after the results are fetched
- I'm not sure what the behavior is when an empty string is passed as the value for `query`. Not being able to set one will mean a larger refactor to support this due to the shared structs
- I could not find documentation on what is supported by `query`, which may result in confusion from users about how to use it and why the results returned are correct

