### PR TITLE
sensible pagination

### DIFF
--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -34,7 +34,12 @@ func parseLimit(limit string) (int, error) {
 	} else if limit == "all" {
 		return 0, nil
 	}
-	return strconv.Atoi(limit)
+
+	v, err := strconv.Atoi(limit)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value '%s' for limit", limit)
+	}
+	return v, nil
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -88,6 +88,7 @@ gh projects field-list 1 --org github --limit 30
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of fields. Defaults to 100. Set to 'none' to list all fields.")
 
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -31,7 +31,7 @@ type listConfig struct {
 func parseLimit(limit string) (int, error) {
 	if limit == "" {
 		return queries.LimitMax, nil
-	} else if limit == "none" {
+	} else if limit == "all" {
 		return 0, nil
 	}
 	return strconv.Atoi(limit)
@@ -88,7 +88,7 @@ gh projects field-list 1 --org github --limit 30
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of fields. Defaults to 100. Set to 'none' to list all fields.")
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of fields. Defaults to 100. Set to 'all' to list all fields.")
 
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -101,6 +101,11 @@ func runList(config listConfig) error {
 		return fmt.Errorf("format must be 'json'")
 	}
 
+	limit, err := parseLimit(config.opts.limit)
+	if err != nil {
+		return err
+	}
+
 	owner, err := queries.NewOwner(config.client, config.opts.userOwner, config.opts.orgOwner)
 	if err != nil {
 		return err
@@ -112,11 +117,6 @@ func runList(config listConfig) error {
 			return err
 		}
 		config.opts.number = project.Number
-	}
-
-	limit, err := parseLimit(config.opts.limit)
-	if err != nil {
-		return err
 	}
 
 	project, err := queries.ProjectFields(config.client, owner, config.opts.number, limit)

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -15,7 +15,7 @@ import (
 )
 
 type listOpts struct {
-	limit     int
+	limit     string
 	userOwner string
 	orgOwner  string
 	number    int
@@ -28,11 +28,13 @@ type listConfig struct {
 	opts   listOpts
 }
 
-func (opts *listOpts) first() int {
-	if opts.limit == 0 {
-		return 100
+func parseLimit(limit string) (int, error) {
+	if limit == "" {
+		return queries.LimitMax, nil
+	} else if limit == "none" {
+		return 0, nil
 	}
-	return opts.limit
+	return strconv.Atoi(limit)
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
@@ -111,7 +113,12 @@ func runList(config listConfig) error {
 		config.opts.number = project.Number
 	}
 
-	project, err := queries.ProjectFields(config.client, owner, config.opts.number, config.opts.first())
+	limit, err := parseLimit(config.opts.limit)
+	if err != nil {
+		return err
+	}
+
+	project, err := queries.ProjectFields(config.client, owner, config.opts.number, limit)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -15,7 +15,7 @@ import (
 )
 
 type listOpts struct {
-	limit     int
+	limit     string
 	userOwner string
 	orgOwner  string
 	number    int
@@ -28,11 +28,13 @@ type listConfig struct {
 	opts   listOpts
 }
 
-func (opts *listOpts) first() int {
-	if opts.limit == 0 {
-		return 100
+func parseLimit(limit string) (int, error) {
+	if limit == "" {
+		return queries.LimitMax, nil
+	} else if limit == "none" {
+		return 0, nil
 	}
-	return opts.limit
+	return strconv.Atoi(limit)
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
@@ -89,7 +91,7 @@ gh projects item-list 1 --org github
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of items. Defaults to 100. Set to 'none' to list all items.")
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")
 
@@ -99,6 +101,11 @@ gh projects item-list 1 --org github
 func runList(config listConfig) error {
 	if config.opts.format != "" && config.opts.format != "json" {
 		return fmt.Errorf("format must be 'json'")
+	}
+
+	limit, err := parseLimit(config.opts.limit)
+	if err != nil {
+		return err
 	}
 
 	owner, err := queries.NewOwner(config.client, config.opts.userOwner, config.opts.orgOwner)
@@ -114,7 +121,7 @@ func runList(config listConfig) error {
 		config.opts.number = project.Number
 	}
 
-	project, err := queries.ProjectItems(config.client, owner, config.opts.number, config.opts.first())
+	project, err := queries.ProjectItems(config.client, owner, config.opts.number, limit)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -34,7 +34,12 @@ func parseLimit(limit string) (int, error) {
 	} else if limit == "all" {
 		return 0, nil
 	}
-	return strconv.Atoi(limit)
+
+	v, err := strconv.Atoi(limit)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value '%s' for limit", limit)
+	}
+	return v, nil
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -31,7 +31,7 @@ type listConfig struct {
 func parseLimit(limit string) (int, error) {
 	if limit == "" {
 		return queries.LimitMax, nil
-	} else if limit == "none" {
+	} else if limit == "all" {
 		return 0, nil
 	}
 	return strconv.Atoi(limit)
@@ -91,7 +91,7 @@ gh projects item-list 1 --org github
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner. Use \"@me\" for the current user.")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of items. Defaults to 100. Set to 'none' to list all items.")
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of items. Defaults to 100. Set to 'all' to list all items.")
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")
 

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -45,7 +45,7 @@ func parseLimit(limit string) (int, error) {
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
 	opts := listOpts{}
 	listCmd := &cobra.Command{
-		Short: "List all of the items in a project",
+		Short: "List the items in a project",
 		Use:   "item-list [number]",
 		Example: `
 The default output is a column format with a subset of system defined fields.

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -89,7 +89,7 @@ gh projects list --org github --closed
 	listCmd.Flags().BoolVarP(&opts.closed, "closed", "c", false, "Show closed projects.")
 	listCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open projects list in the browser.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'all' to list all projects.")
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'all' to list all projects. Note that closed projects are filtered from the final results without the --closed flag.")
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -31,13 +31,13 @@ type listConfig struct {
 	URLOpener func(string) error
 }
 
-func (opts *listOpts) parseLimit() (int, error) {
-	if opts.limit == "" {
+func parseLimit(limit string) (int, error) {
+	if limit == "" {
 		return queries.LimitMax, nil
-	} else if opts.limit == "all" {
+	} else if limit == "all" {
 		return 0, nil
 	}
-	return strconv.Atoi(opts.limit)
+	return strconv.Atoi(limit)
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {
@@ -132,7 +132,7 @@ func runList(config listConfig) error {
 		ownerType = queries.ViewerOwner
 	}
 
-	limit, err := config.opts.parseLimit()
+	limit, err := parseLimit(config.opts.limit)
 	if err != nil {
 		return err
 	}

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -34,7 +34,7 @@ type listConfig struct {
 func (opts *listOpts) parseLimit() (int, error) {
 	if opts.limit == "" {
 		return queries.LimitMax, nil
-	} else if opts.limit == "none" {
+	} else if opts.limit == "all" {
 		return 0, nil
 	}
 	return strconv.Atoi(opts.limit)
@@ -86,11 +86,11 @@ gh projects list --org github --closed
 
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
-	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'none' to list all projects.")
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'all' to list all projects.")
 	listCmd.Flags().BoolVarP(&opts.closed, "closed", "c", false, "Show closed projects.")
 	listCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open projects list in the browser.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")
-
+	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'all' to list all projects.")
 	// owner can be a user or an org
 	listCmd.MarkFlagsMutuallyExclusive("user", "org")
 

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -37,7 +37,12 @@ func parseLimit(limit string) (int, error) {
 	} else if limit == "all" {
 		return 0, nil
 	}
-	return strconv.Atoi(limit)
+
+	v, err := strconv.Atoi(limit)
+	if err != nil {
+		return 0, fmt.Errorf("invalid value '%s' for limit", limit)
+	}
+	return v, nil
 }
 
 func NewCmdList(f *cmdutil.Factory, runF func(config listConfig) error) *cobra.Command {

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -86,7 +86,6 @@ gh projects list --org github --closed
 
 	listCmd.Flags().StringVar(&opts.userOwner, "user", "", "Login of the user owner")
 	listCmd.Flags().StringVar(&opts.orgOwner, "org", "", "Login of the organization owner.")
-	listCmd.Flags().StringVar(&opts.limit, "limit", "", "Maximum number of projects. Defaults to 100. Set to 'all' to list all projects.")
 	listCmd.Flags().BoolVarP(&opts.closed, "closed", "c", false, "Show closed projects.")
 	listCmd.Flags().BoolVarP(&opts.web, "web", "w", false, "Open projects list in the browser.")
 	listCmd.Flags().StringVar(&opts.format, "format", "", "Output format, must be 'json'.")

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -113,6 +113,11 @@ func runList(config listConfig) error {
 		return fmt.Errorf("format must be 'json'")
 	}
 
+	limit, err := parseLimit(config.opts.limit)
+	if err != nil {
+		return err
+	}
+
 	var login string
 	var ownerType queries.OwnerType
 	if config.opts.userOwner != "" {
@@ -129,11 +134,6 @@ func runList(config listConfig) error {
 	} else {
 		login = "me"
 		ownerType = queries.ViewerOwner
-	}
-
-	limit, err := parseLimit(config.opts.limit)
-	if err != nil {
-		return err
 	}
 
 	projects, totalCount, err := queries.Projects(config.client, login, ownerType, limit)

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -996,7 +996,7 @@ func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Pro
 	// the api limits batches to 100. We want to use the maximum batch size unless the user
 	// requested a lower limit.
 	first := LimitMax
-	if limit < first {
+	if hasLimit && limit < first {
 		first = limit
 	}
 	// loop until we get all the projects

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -374,7 +374,7 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (Projec
 	variables["first"] = graphql.Int(LimitMax)
 
 	for {
-		if !hasNextPage || (hasLimit && len(project.Items.Nodes) > limit) {
+		if !hasNextPage || (hasLimit && len(project.Items.Nodes) >= limit) {
 			return project, nil
 		}
 		// set the cursor to the end of the last page
@@ -512,7 +512,7 @@ func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (Proje
 	variables["first"] = graphql.Int(LimitMax)
 
 	for {
-		if !hasNextPage || (hasLimit && len(project.Fields.Nodes) > limit) {
+		if !hasNextPage || (hasLimit && len(project.Fields.Nodes) >= limit) {
 			return project, nil
 		}
 
@@ -1047,7 +1047,7 @@ func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Pro
 			totalCount = query.Owner.Projects.TotalCount
 		}
 
-		if !hasNextPage || (hasLimit && len(projects) > limit) {
+		if !hasNextPage || (hasLimit && len(projects) >= limit) {
 			return projects, totalCount, nil
 		}
 		first = LimitMax // reset to the default batch size on loops after the first

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -1050,6 +1050,5 @@ func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Pro
 		if !hasNextPage || (hasLimit && len(projects) >= limit) {
 			return projects, totalCount, nil
 		}
-		first = LimitMax // reset to the default batch size on loops after the first
 	}
 }

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -1050,5 +1050,9 @@ func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Pro
 		if !hasNextPage || (hasLimit && len(projects) >= limit) {
 			return projects, totalCount, nil
 		}
+
+		if len(projects)+LimitMax > limit {
+			first = limit - len(projects)
+		}
 	}
 }

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -378,11 +378,11 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (Projec
 	cursor := project.Items.PageInfo.EndCursor
 
 	for {
-		if !hasNextPage || len(project.Items.Nodes) >= limit {
+		if !hasNextPage || (hasLimit && len(project.Items.Nodes) >= limit) {
 			return project, nil
 		}
 
-		if len(project.Items.Nodes)+LimitMax > limit {
+		if hasLimit && len(project.Items.Nodes)+LimitMax > limit {
 			first := limit - len(project.Items.Nodes)
 			variables["first"] = graphql.Int(first)
 		}
@@ -531,7 +531,7 @@ func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (Proje
 			return project, nil
 		}
 
-		if len(project.Fields.Nodes)+LimitMax > limit {
+		if hasLimit && len(project.Fields.Nodes)+LimitMax > limit {
 			first := limit - len(project.Fields.Nodes)
 			variables["first"] = graphql.Int(first)
 		}


### PR DESCRIPTION
`limit` option for
- list
- item-list
- field-list

If not set, defaults to 100. Otherwise, the value must be either `all` to fetch everything, or an integer value.

The pagination code has become messy, I plan to refactor it at some point soon.