### PR TITLE
refactor queries

### DIFF
--- a/cmd/close/close.go
+++ b/cmd/close/close.go
@@ -104,7 +104,7 @@ func runClose(config closeConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/close/close.go
+++ b/cmd/close/close.go
@@ -131,6 +131,10 @@ func closeArgs(config closeConfig) (*updateProjectMutation, map[string]interface
 			ProjectID: githubv4.ID(config.opts.projectID),
 			Closed:    githubv4.NewBoolean(githubv4.Boolean(closed)),
 		},
+		"firstItems":  githubv4.Int(queries.LimitMax),
+		"afterItems":  (*githubv4.String)(nil),
+		"firstFields": githubv4.Int(queries.LimitMax),
+		"afterFields": (*githubv4.String)(nil),
 	}
 }
 

--- a/cmd/close/close.go
+++ b/cmd/close/close.go
@@ -131,9 +131,9 @@ func closeArgs(config closeConfig) (*updateProjectMutation, map[string]interface
 			ProjectID: githubv4.ID(config.opts.projectID),
 			Closed:    githubv4.NewBoolean(githubv4.Boolean(closed)),
 		},
-		"firstItems":  githubv4.Int(queries.LimitMax),
+		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),
-		"firstFields": githubv4.Int(queries.LimitMax),
+		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
 	}
 }

--- a/cmd/close/close_test.go
+++ b/cmd/close/close_test.go
@@ -43,9 +43,9 @@ func TestRunClose_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -132,9 +132,9 @@ func TestRunClose_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -217,9 +217,9 @@ func TestRunClose_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -306,9 +306,9 @@ func TestRunClose_Reopen(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/close/close_test.go
+++ b/cmd/close/close_test.go
@@ -41,8 +41,12 @@ func TestRunClose_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -59,7 +63,7 @@ func TestRunClose_User(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -126,8 +130,12 @@ func TestRunClose_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -144,7 +152,7 @@ func TestRunClose_Org(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -208,7 +216,11 @@ func TestRunClose_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -225,7 +237,7 @@ func TestRunClose_Me(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -292,8 +304,12 @@ func TestRunClose_Reopen(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -310,7 +326,7 @@ func TestRunClose_Reopen(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"input":{"projectId":"an ID","closed":false}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/close/close_test.go
+++ b/cmd/close/close_test.go
@@ -63,7 +63,7 @@ func TestRunClose_User(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -152,7 +152,7 @@ func TestRunClose_Org(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -237,7 +237,7 @@ func TestRunClose_Me(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":true}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -326,7 +326,7 @@ func TestRunClose_Reopen(t *testing.T) {
 	// close project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","closed":false}}}`).
+		BodyString(`{"query":"mutation CloseProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","closed":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -148,9 +148,9 @@ func copyArgs(config copyConfig) (*copyProjectMutation, map[string]interface{}) 
 			Title:              githubv4.String(config.opts.title),
 			IncludeDraftIssues: githubv4.NewBoolean(githubv4.Boolean(config.opts.includeDraftIssues)),
 		},
-		"firstItems":  githubv4.Int(queries.LimitMax),
+		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),
-		"firstFields": githubv4.Int(queries.LimitMax),
+		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
 	}
 }

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -148,6 +148,10 @@ func copyArgs(config copyConfig) (*copyProjectMutation, map[string]interface{}) 
 			Title:              githubv4.String(config.opts.title),
 			IncludeDraftIssues: githubv4.NewBoolean(githubv4.Boolean(config.opts.includeDraftIssues)),
 		},
+		"firstItems":  githubv4.Int(queries.LimitMax),
+		"afterItems":  (*githubv4.String)(nil),
+		"firstFields": githubv4.Int(queries.LimitMax),
+		"afterFields": (*githubv4.String)(nil),
 	}
 }
 

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -118,7 +118,7 @@ func runCopy(config copyConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, sourceOwner, config.opts.number)
+	project, err := queries.NewProject(config.client, sourceOwner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/copy/copy_test.go
+++ b/cmd/copy/copy_test.go
@@ -22,8 +22,12 @@ func TestRunCopy_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -80,7 +84,7 @@ func TestRunCopy_User(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -130,8 +134,12 @@ func TestRunCopy_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -187,7 +195,7 @@ func TestRunCopy_Org(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -236,7 +244,11 @@ func TestRunCopy_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -287,7 +299,7 @@ func TestRunCopy_Me(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).Reply(200).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"copyProjectV2": map[string]interface{}{

--- a/cmd/copy/copy_test.go
+++ b/cmd/copy/copy_test.go
@@ -84,7 +84,7 @@ func TestRunCopy_User(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -195,7 +195,7 @@ func TestRunCopy_Org(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -299,7 +299,7 @@ func TestRunCopy_Me(t *testing.T) {
 	// Copy project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).Reply(200).
+		BodyString(`{"query":"mutation CopyProjectV2.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","ownerId":"an ID","title":"a title","includeDraftIssues":false}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"copyProjectV2": map[string]interface{}{

--- a/cmd/copy/copy_test.go
+++ b/cmd/copy/copy_test.go
@@ -24,9 +24,9 @@ func TestRunCopy_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -136,9 +136,9 @@ func TestRunCopy_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -245,9 +245,9 @@ func TestRunCopy_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -115,6 +115,10 @@ func createArgs(config createConfig) (*createProjectMutation, map[string]interfa
 			OwnerID: githubv4.ID(config.opts.ownerID),
 			Title:   githubv4.String(config.opts.title),
 		},
+		"firstItems":  githubv4.Int(queries.LimitMax),
+		"afterItems":  (*githubv4.String)(nil),
+		"firstFields": githubv4.Int(queries.LimitMax),
+		"afterFields": (*githubv4.String)(nil),
 	}
 }
 

--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -115,9 +115,9 @@ func createArgs(config createConfig) (*createProjectMutation, map[string]interfa
 			OwnerID: githubv4.ID(config.opts.ownerID),
 			Title:   githubv4.String(config.opts.title),
 		},
-		"firstItems":  githubv4.Int(queries.LimitMax),
+		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),
-		"firstFields": githubv4.Int(queries.LimitMax),
+		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
 	}
 }

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -38,7 +38,7 @@ func TestRunCreate_User(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"input":{"ownerId":"an ID","title":"a title"}}}`).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -101,7 +101,7 @@ func TestRunCreate_Org(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"createProjectV2": map[string]interface{}{
@@ -160,7 +160,7 @@ func TestRunCreate_Me(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"createProjectV2": map[string]interface{}{

--- a/cmd/create/create_test.go
+++ b/cmd/create/create_test.go
@@ -38,7 +38,7 @@ func TestRunCreate_User(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -101,7 +101,7 @@ func TestRunCreate_Org(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"createProjectV2": map[string]interface{}{
@@ -160,7 +160,7 @@ func TestRunCreate_Me(t *testing.T) {
 	// create project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
+		BodyString(`{"query":"mutation CreateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"ownerId":"an ID","title":"a title"}}}`).Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
 				"createProjectV2": map[string]interface{}{

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -127,9 +127,9 @@ func deleteItemArgs(config deleteConfig) (*deleteProjectMutation, map[string]int
 		"input": githubv4.DeleteProjectV2Input{
 			ProjectID: githubv4.ID(config.opts.projectID),
 		},
-		"firstItems":  githubv4.Int(queries.LimitMax),
+		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),
-		"firstFields": githubv4.Int(queries.LimitMax),
+		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
 	}
 }

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -127,6 +127,10 @@ func deleteItemArgs(config deleteConfig) (*deleteProjectMutation, map[string]int
 		"input": githubv4.DeleteProjectV2Input{
 			ProjectID: githubv4.ID(config.opts.projectID),
 		},
+		"firstItems":  githubv4.Int(queries.LimitMax),
+		"afterItems":  (*githubv4.String)(nil),
+		"firstFields": githubv4.Int(queries.LimitMax),
+		"afterFields": (*githubv4.String)(nil),
 	}
 }
 

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -102,7 +102,7 @@ func runDelete(config deleteConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/delete/delete_test.go
+++ b/cmd/delete/delete_test.go
@@ -43,9 +43,9 @@ func TestRunDelete_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -128,9 +128,9 @@ func TestRunDelete_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -209,9 +209,9 @@ func TestRunDelete_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/delete/delete_test.go
+++ b/cmd/delete/delete_test.go
@@ -41,8 +41,12 @@ func TestRunDelete_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -59,7 +63,7 @@ func TestRunDelete_User(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -122,8 +126,12 @@ func TestRunDelete_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -140,7 +148,7 @@ func TestRunDelete_Org(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -200,7 +208,11 @@ func TestRunDelete_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -217,7 +229,7 @@ func TestRunDelete_Me(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/delete/delete_test.go
+++ b/cmd/delete/delete_test.go
@@ -63,7 +63,7 @@ func TestRunDelete_User(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -148,7 +148,7 @@ func TestRunDelete_Org(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -229,7 +229,7 @@ func TestRunDelete_Me(t *testing.T) {
 	// delete project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID"}}}`).
+		BodyString(`{"query":"mutation DeleteProject.*","variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -121,7 +121,7 @@ func runEdit(config editConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -160,7 +160,11 @@ func editArgs(config editConfig) (*updateProjectMutation, map[string]interface{}
 	}
 
 	return &updateProjectMutation{}, map[string]interface{}{
-		"input": variables,
+		"input":       variables,
+		"firstItems":  githubv4.Int(queries.LimitMax),
+		"afterItems":  (*githubv4.String)(nil),
+		"firstFields": githubv4.Int(queries.LimitMax),
+		"afterFields": (*githubv4.String)(nil),
 	}
 }
 

--- a/cmd/edit/edit.go
+++ b/cmd/edit/edit.go
@@ -161,9 +161,9 @@ func editArgs(config editConfig) (*updateProjectMutation, map[string]interface{}
 
 	return &updateProjectMutation{}, map[string]interface{}{
 		"input":       variables,
-		"firstItems":  githubv4.Int(queries.LimitMax),
+		"firstItems":  githubv4.Int(0),
 		"afterItems":  (*githubv4.String)(nil),
-		"firstFields": githubv4.Int(queries.LimitMax),
+		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
 	}
 }

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -43,9 +43,9 @@ func TestRunUpdate_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -135,9 +135,9 @@ func TestRunUpdate_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -223,9 +223,9 @@ func TestRunUpdate_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -315,9 +315,9 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -41,8 +41,12 @@ func TestRunUpdate_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -59,7 +63,7 @@ func TestRunUpdate_User(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -129,8 +133,12 @@ func TestRunUpdate_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -147,7 +155,7 @@ func TestRunUpdate_Org(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -214,7 +222,11 @@ func TestRunUpdate_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -231,7 +243,7 @@ func TestRunUpdate_Me(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":false}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -301,8 +313,12 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -319,7 +335,7 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 	// Update project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"input":{"projectId":"an ID","title":"another title"}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"another title"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/edit/edit_test.go
+++ b/cmd/edit/edit_test.go
@@ -63,7 +63,7 @@ func TestRunUpdate_User(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -155,7 +155,7 @@ func TestRunUpdate_Org(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":true}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -243,7 +243,7 @@ func TestRunUpdate_Me(t *testing.T) {
 	// edit project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":false}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"a new title","shortDescription":"a new description","readme":"a new readme","public":false}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{
@@ -335,7 +335,7 @@ func TestRunUpdate_OmitParams(t *testing.T) {
 	// Update project
 	gock.New("https://api.github.com").
 		Post("/graphql").
-		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":100,"firstItems":100,"input":{"projectId":"an ID","title":"another title"}}}`).
+		BodyString(`{"query":"mutation UpdateProjectV2.*"variables":{"afterFields":null,"afterItems":null,"firstFields":0,"firstItems":0,"input":{"projectId":"an ID","title":"another title"}}}`).
 		Reply(200).
 		JSON(map[string]interface{}{
 			"data": map[string]interface{}{

--- a/cmd/field-create/field_create.go
+++ b/cmd/field-create/field_create.go
@@ -117,7 +117,7 @@ func runCreateField(config createFieldConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/field-create/field_create_test.go
+++ b/cmd/field-create/field_create_test.go
@@ -43,9 +43,9 @@ func TestRunCreateField_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -130,9 +130,9 @@ func TestRunCreateField_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -212,9 +212,9 @@ func TestRunCreateField_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -294,9 +294,9 @@ func TestRunCreateField_TEXT(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -376,9 +376,9 @@ func TestRunCreateField_DATE(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -458,9 +458,9 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/field-create/field_create_test.go
+++ b/cmd/field-create/field_create_test.go
@@ -41,8 +41,12 @@ func TestRunCreateField_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -124,8 +128,12 @@ func TestRunCreateField_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -203,7 +211,11 @@ func TestRunCreateField_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -281,7 +293,11 @@ func TestRunCreateField_TEXT(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -359,7 +375,11 @@ func TestRunCreateField_DATE(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -437,7 +457,11 @@ func TestRunCreateField_NUMBER(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -116,6 +116,7 @@ func runList(config listConfig) error {
 		return err
 	}
 
+	// no need to fetch the project if we already have the number
 	if config.opts.number == 0 {
 		project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 		if err != nil {
@@ -158,7 +159,7 @@ func printResults(config listConfig, fields []queries.ProjectField, login string
 	return config.tp.Render()
 }
 
-func printJSON(config listConfig, project queries.Project) error {
+func printJSON(config listConfig, project *queries.Project) error {
 	b, err := format.JSONProjectFields(project)
 	if err != nil {
 		return err

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -158,7 +158,7 @@ func printResults(config listConfig, fields []queries.ProjectField, login string
 	return config.tp.Render()
 }
 
-func printJSON(config listConfig, project queries.ProjectWithFields) error {
+func printJSON(config listConfig, project queries.Project) error {
 	b, err := format.JSONProjectFields(project)
 	if err != nil {
 		return err

--- a/cmd/field-list/field_list.go
+++ b/cmd/field-list/field_list.go
@@ -117,7 +117,7 @@ func runList(config listConfig) error {
 	}
 
 	if config.opts.number == 0 {
-		project, err := queries.NewProject(config.client, owner, config.opts.number)
+		project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/field-list/field_list_test.go
+++ b/cmd/field-list/field_list_test.go
@@ -38,7 +38,7 @@ func TestRunList_User(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		JSON(map[string]interface{}{
-			"query": "query UserProjectWithFields.*",
+			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
 				"login":  "monalisa",
 				"number": 1,
@@ -122,7 +122,7 @@ func TestRunList_Org(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		JSON(map[string]interface{}{
-			"query": "query OrgProjectWithFields.*",
+			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
 				"login":  "github",
 				"number": 1,
@@ -204,7 +204,7 @@ func TestRunList_Me(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		JSON(map[string]interface{}{
-			"query": "query ViewerProjectWithFields.*",
+			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number": 1,
 				"first":  100,
@@ -285,7 +285,7 @@ func TestRunList_Empty(t *testing.T) {
 	gock.New("https://api.github.com").
 		Post("/graphql").
 		JSON(map[string]interface{}{
-			"query": "query ViewerProjectWithFields.*",
+			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number": 1,
 				"first":  100,

--- a/cmd/field-list/field_list_test.go
+++ b/cmd/field-list/field_list_test.go
@@ -40,10 +40,12 @@ func TestRunList_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
-				"first":  100,
-				"after":  nil,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -124,10 +126,12 @@ func TestRunList_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
-				"first":  100,
-				"after":  nil,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -206,9 +210,11 @@ func TestRunList_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
-				"first":  100,
-				"after":  nil,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -287,9 +293,11 @@ func TestRunList_Empty(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
-				"first":  100,
-				"after":  nil,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-add/item_add.go
+++ b/cmd/item-add/item_add.go
@@ -106,7 +106,7 @@ func runAddItem(config addItemConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-add/item_add_test.go
+++ b/cmd/item-add/item_add_test.go
@@ -43,9 +43,9 @@ func TestRunAddItem_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -148,9 +148,9 @@ func TestRunAddItem_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -249,9 +249,9 @@ func TestRunAddItem_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/item-add/item_add_test.go
+++ b/cmd/item-add/item_add_test.go
@@ -41,8 +41,12 @@ func TestRunAddItem_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -142,8 +146,12 @@ func TestRunAddItem_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -240,7 +248,11 @@ func TestRunAddItem_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-archive/item_archive.go
+++ b/cmd/item-archive/item_archive.go
@@ -116,7 +116,7 @@ func runArchiveItem(config archiveItemConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-archive/item_archive_test.go
+++ b/cmd/item-archive/item_archive_test.go
@@ -43,9 +43,9 @@ func TestRunArchive_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -128,9 +128,9 @@ func TestRunArchive_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -209,9 +209,9 @@ func TestRunArchive_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -294,9 +294,9 @@ func TestRunArchive_User_Undo(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -380,9 +380,9 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -462,9 +462,9 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/item-archive/item_archive_test.go
+++ b/cmd/item-archive/item_archive_test.go
@@ -41,8 +41,12 @@ func TestRunArchive_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -122,8 +126,12 @@ func TestRunArchive_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -200,7 +208,11 @@ func TestRunArchive_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -280,8 +292,12 @@ func TestRunArchive_User_Undo(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -362,8 +378,12 @@ func TestRunArchive_Org_Undo(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -441,7 +461,11 @@ func TestRunArchive_Me_Undo(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-create/item_create.go
+++ b/cmd/item-create/item_create.go
@@ -107,7 +107,7 @@ func runCreateItem(config createItemConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-create/item_create_test.go
+++ b/cmd/item-create/item_create_test.go
@@ -40,8 +40,12 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -121,8 +125,12 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -199,7 +207,11 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-create/item_create_test.go
+++ b/cmd/item-create/item_create_test.go
@@ -42,9 +42,9 @@ func TestRunCreateItem_Draft_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -127,9 +127,9 @@ func TestRunCreateItem_Draft_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -208,9 +208,9 @@ func TestRunCreateItem_Draft_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/item-delete/item_delete.go
+++ b/cmd/item-delete/item_delete.go
@@ -104,7 +104,7 @@ func runDeleteItem(config deleteItemConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/item-delete/item_delete_test.go
+++ b/cmd/item-delete/item_delete_test.go
@@ -40,8 +40,12 @@ func TestRunDelete_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProject.*",
 			"variables": map[string]interface{}{
-				"login":  "monalisa",
-				"number": 1,
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -119,8 +123,12 @@ func TestRunDelete_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProject.*",
 			"variables": map[string]interface{}{
-				"login":  "github",
-				"number": 1,
+				"login":       "github",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).
@@ -195,7 +203,11 @@ func TestRunDelete_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
-				"number": 1,
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-delete/item_delete_test.go
+++ b/cmd/item-delete/item_delete_test.go
@@ -42,9 +42,9 @@ func TestRunDelete_User(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -125,9 +125,9 @@ func TestRunDelete_Org(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "github",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).
@@ -204,9 +204,9 @@ func TestRunDelete_Me(t *testing.T) {
 			"query": "query ViewerProject.*",
 			"variables": map[string]interface{}{
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  0,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": 0,
 				"afterFields": nil,
 			},
 		}).

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -119,7 +119,7 @@ func runList(config listConfig) error {
 	}
 
 	if config.opts.number == 0 {
-		project, err := queries.NewProject(config.client, owner, config.opts.number)
+		project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 		if err != nil {
 			return err
 		}

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -172,7 +172,7 @@ func printResults(config listConfig, items []queries.ProjectItem, login string) 
 	return config.tp.Render()
 }
 
-func printJSON(config listConfig, project queries.ProjectWithItems) error {
+func printJSON(config listConfig, project queries.Project) error {
 	b, err := format.JSONProjectDetailedItems(project)
 	if err != nil {
 		return err

--- a/cmd/item-list/item_list.go
+++ b/cmd/item-list/item_list.go
@@ -118,6 +118,7 @@ func runList(config listConfig) error {
 		return err
 	}
 
+	// no need to fetch the project if we already have the number
 	if config.opts.number == 0 {
 		project, err := queries.NewProject(config.client, owner, config.opts.number, false)
 		if err != nil {
@@ -172,7 +173,7 @@ func printResults(config listConfig, items []queries.ProjectItem, login string) 
 	return config.tp.Render()
 }
 
-func printJSON(config listConfig, project queries.Project) error {
+func printJSON(config listConfig, project *queries.Project) error {
 	b, err := format.JSONProjectDetailedItems(project)
 	if err != nil {
 		return err

--- a/cmd/item-list/item_list_test.go
+++ b/cmd/item-list/item_list_test.go
@@ -39,10 +39,12 @@ func TestRunList_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"first":  100,
-				"login":  "monalisa",
-				"number": 1,
-				"after":  nil,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
 			},
 		}).
 		Reply(200).
@@ -137,10 +139,12 @@ func TestRunList_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"first":  100,
-				"login":  "github",
-				"number": 1,
-				"after":  nil,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"login":       "github",
+				"number":      1,
 			},
 		}).
 		Reply(200).
@@ -233,9 +237,11 @@ func TestRunList_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"first":  100,
-				"number": 1,
-				"after":  nil,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"number":      1,
 			},
 		}).
 		Reply(200).

--- a/cmd/item-list/item_list_test.go
+++ b/cmd/item-list/item_list_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/cli/go-gh"
 	"github.com/cli/go-gh/pkg/api"
 	"github.com/cli/go-gh/pkg/tableprinter"
+	"github.com/github/gh-projects/queries"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/h2non/gock.v1"
 )
@@ -39,9 +40,9 @@ func TestRunList_User(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"firstItems":  100,
+				"firstItems":  queries.LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": queries.LimitMax,
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
@@ -139,9 +140,9 @@ func TestRunList_Org(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query OrgProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"firstItems":  100,
+				"firstItems":  queries.LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": queries.LimitMax,
 				"afterFields": nil,
 				"login":       "github",
 				"number":      1,
@@ -237,9 +238,9 @@ func TestRunList_Me(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query ViewerProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"firstItems":  100,
+				"firstItems":  queries.LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": queries.LimitMax,
 				"afterFields": nil,
 				"number":      1,
 			},

--- a/cmd/list/list.go
+++ b/cmd/list/list.go
@@ -141,7 +141,7 @@ func runList(config listConfig) error {
 		ownerType = queries.ViewerOwner
 	}
 
-	projects, totalCount, err := queries.Projects(config.client, login, ownerType, limit)
+	projects, totalCount, err := queries.Projects(config.client, login, ownerType, limit, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/view/view.go
+++ b/cmd/view/view.go
@@ -118,7 +118,7 @@ func runView(config viewConfig) error {
 		return err
 	}
 
-	project, err := queries.NewProject(config.client, owner, config.opts.number)
+	project, err := queries.NewProject(config.client, owner, config.opts.number, true)
 	if err != nil {
 		return err
 	}

--- a/format/json.go
+++ b/format/json.go
@@ -113,7 +113,7 @@ func JSONProjectField(field queries.ProjectField) ([]byte, error) {
 
 // JSONProjectFields serializes a slice of ProjectFields to JSON.
 // JSON fields are `totalCount` and `fields`.
-func JSONProjectFields(project queries.ProjectWithFields) ([]byte, error) {
+func JSONProjectFields(project queries.Project) ([]byte, error) {
 	var result []projectFieldJSON
 	for _, f := range project.Fields.Nodes {
 		result = append(result, projectFieldJSON{
@@ -285,7 +285,7 @@ func projectFieldValueData(v queries.FieldValueNodes) any {
 }
 
 // serialize creates a map from field to field values
-func serializeProjectWithItems(project queries.ProjectWithItems) []map[string]any {
+func serializeProjectWithItems(project queries.Project) []map[string]any {
 	fields := make(map[string]string)
 
 	// make a map of fields by ID
@@ -313,7 +313,7 @@ func serializeProjectWithItems(project queries.ProjectWithItems) []map[string]an
 
 // JSONProjectWithItems returns a detailed JSON representation of project items.
 // JSON fields are `totalCount` and `items`.
-func JSONProjectDetailedItems(project queries.ProjectWithItems) ([]byte, error) {
+func JSONProjectDetailedItems(project queries.Project) ([]byte, error) {
 	items := serializeProjectWithItems(project)
 	return json.Marshal(struct {
 		Items      []map[string]any `json:"items"`

--- a/format/json.go
+++ b/format/json.go
@@ -113,7 +113,7 @@ func JSONProjectField(field queries.ProjectField) ([]byte, error) {
 
 // JSONProjectFields serializes a slice of ProjectFields to JSON.
 // JSON fields are `totalCount` and `fields`.
-func JSONProjectFields(project queries.Project) ([]byte, error) {
+func JSONProjectFields(project *queries.Project) ([]byte, error) {
 	var result []projectFieldJSON
 	for _, f := range project.Fields.Nodes {
 		result = append(result, projectFieldJSON{
@@ -285,7 +285,7 @@ func projectFieldValueData(v queries.FieldValueNodes) any {
 }
 
 // serialize creates a map from field to field values
-func serializeProjectWithItems(project queries.Project) []map[string]any {
+func serializeProjectWithItems(project *queries.Project) []map[string]any {
 	fields := make(map[string]string)
 
 	// make a map of fields by ID
@@ -313,7 +313,7 @@ func serializeProjectWithItems(project queries.Project) []map[string]any {
 
 // JSONProjectWithItems returns a detailed JSON representation of project items.
 // JSON fields are `totalCount` and `items`.
-func JSONProjectDetailedItems(project queries.Project) ([]byte, error) {
+func JSONProjectDetailedItems(project *queries.Project) ([]byte, error) {
 	items := serializeProjectWithItems(project)
 	return json.Marshal(struct {
 		Items      []map[string]any `json:"items"`

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -127,11 +127,11 @@ func TestJSONProjectFields(t *testing.T) {
 	field.Field.ID = "123"
 	field.Field.Name = "name"
 
-	p := queries.ProjectWithFields{
+	p := queries.Project{
 		Fields: struct {
-			PageInfo   queries.PageInfo
-			Nodes      []queries.ProjectField
 			TotalCount int
+			Nodes      []queries.ProjectField
+			PageInfo   queries.PageInfo
 		}{
 			Nodes:      []queries.ProjectField{field},
 			TotalCount: 5,
@@ -170,7 +170,7 @@ func TestJSONProjectItem_Issue(t *testing.T) {
 }
 
 func TestJSONProjectDetailedItems(t *testing.T) {
-	p := queries.ProjectWithItems{}
+	p := queries.Project{}
 	p.Items.TotalCount = 5
 	p.Items.Nodes = []queries.ProjectItem{
 		{

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -127,7 +127,7 @@ func TestJSONProjectFields(t *testing.T) {
 	field.Field.ID = "123"
 	field.Field.Name = "name"
 
-	p := queries.Project{
+	p := &queries.Project{
 		Fields: struct {
 			TotalCount int
 			Nodes      []queries.ProjectField
@@ -170,7 +170,7 @@ func TestJSONProjectItem_Issue(t *testing.T) {
 }
 
 func TestJSONProjectDetailedItems(t *testing.T) {
-	p := queries.Project{}
+	p := &queries.Project{}
 	p.Items.TotalCount = 5
 	p.Items.Nodes = []queries.ProjectItem{
 		{

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -1015,7 +1015,7 @@ func NewProject(client api.GQLClient, o *Owner, number int, fields bool) (*Proje
 		return nil, errors.New("unknown owner type")
 	}
 
-	projects, _, err := Projects(client, o.Login, o.Type, 0)
+	projects, _, err := Projects(client, o.Login, o.Type, 0, fields)
 	if err != nil {
 		return nil, err
 	}
@@ -1051,7 +1051,7 @@ func NewProject(client api.GQLClient, o *Owner, number int, fields bool) (*Proje
 }
 
 // Projects returns all the projects for an Owner. If the OwnerType is VIEWER, no login is required.
-func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Project, int, error) {
+func Projects(client api.GQLClient, login string, t OwnerType, limit int, fields bool) ([]Project, int, error) {
 	projects := make([]Project, 0)
 	cursor := (*githubv4.String)(nil)
 	hasNextPage := false
@@ -1072,6 +1072,10 @@ func Projects(client api.GQLClient, login string, t OwnerType, limit int) ([]Pro
 		"afterItems":  (*githubv4.String)(nil),
 		"firstFields": githubv4.Int(0),
 		"afterFields": (*githubv4.String)(nil),
+	}
+
+	if fields {
+		variables["firstFields"] = githubv4.Int(LimitMax)
 	}
 
 	if t != ViewerOwner {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -475,6 +475,10 @@ func (q viewerOwnerWithFields) Project() Project {
 	return q.Owner.Project
 }
 
+type projectAttribute interface {
+	ProjectItem | ProjectField
+}
+
 // paginateAttributes is for paginating over the attributes of a project, such as items or fields
 //
 // firstKey and afterKey are the keys in the variables map that are used to set the first and after
@@ -485,7 +489,7 @@ func (q viewerOwnerWithFields) Project() Project {
 // nodes is the list of attributes that have already been fetched.
 //
 // the return value is a slice of the newly fetched attributes appended to nodes.
-func paginateAttributes[N any](client api.GQLClient, p pager[N], variables map[string]any, firstKey string, afterKey string, limit int, nodes []N) ([]N, error) {
+func paginateAttributes[N projectAttribute](client api.GQLClient, p pager[N], variables map[string]any, firstKey string, afterKey string, limit int, nodes []N) ([]N, error) {
 	hasNextPage := p.HasNextPage()
 	cursor := p.EndCursor()
 	hasLimit := limit != 0

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -983,6 +983,7 @@ func NewOwner(client api.GQLClient, userLogin, orgLogin string) (*Owner, error) 
 // NewProject creates a project based on the owner and project number
 // if number is 0 it will prompt the user to select a project interactively
 // otherwise it will make a request to get the project by number
+// set `fields“ to true to get the project's field data
 func NewProject(client api.GQLClient, o *Owner, number int, fields bool) (*Project, error) {
 	if number != 0 {
 		variables := map[string]interface{}{

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -297,8 +297,8 @@ func (p ProjectItem) Repo() string {
 }
 
 // ProjectItems returns the items of a project. If the OwnerType is VIEWER, no login is required.
-func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (Project, error) {
-	project := Project{}
+func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (*Project, error) {
+	project := &Project{}
 	hasLimit := limit != 0
 	// the api limits batches to 100. We want to use the maximum batch size unless the user
 	// requested a lower limit.
@@ -346,7 +346,7 @@ type pager[N any] interface {
 	EndCursor() string
 	Nodes() []N
 	QueryName() string
-	Project() Project
+	Project() *Project
 }
 
 // userOwnerWithItems
@@ -366,8 +366,8 @@ func (q userOwnerWithItems) QueryName() string {
 	return "UserProjectWithItems"
 }
 
-func (q userOwnerWithItems) Project() Project {
-	return q.Owner.Project
+func (q userOwnerWithItems) Project() *Project {
+	return &q.Owner.Project
 }
 
 // orgOwnerWithItems
@@ -387,8 +387,8 @@ func (q orgOwnerWithItems) QueryName() string {
 	return "OrgProjectWithItems"
 }
 
-func (q orgOwnerWithItems) Project() Project {
-	return q.Owner.Project
+func (q orgOwnerWithItems) Project() *Project {
+	return &q.Owner.Project
 }
 
 // viewerOwnerWithItems
@@ -408,8 +408,8 @@ func (q viewerOwnerWithItems) QueryName() string {
 	return "ViewerProjectWithItems"
 }
 
-func (q viewerOwnerWithItems) Project() Project {
-	return q.Owner.Project
+func (q viewerOwnerWithItems) Project() *Project {
+	return &q.Owner.Project
 }
 
 // userOwnerWithFields
@@ -429,8 +429,8 @@ func (q userOwnerWithFields) QueryName() string {
 	return "UserProjectWithFields"
 }
 
-func (q userOwnerWithFields) Project() Project {
-	return q.Owner.Project
+func (q userOwnerWithFields) Project() *Project {
+	return &q.Owner.Project
 }
 
 // orgOwnerWithFields
@@ -450,8 +450,8 @@ func (q orgOwnerWithFields) QueryName() string {
 	return "OrgProjectWithFields"
 }
 
-func (q orgOwnerWithFields) Project() Project {
-	return q.Owner.Project
+func (q orgOwnerWithFields) Project() *Project {
+	return &q.Owner.Project
 }
 
 // viewerOwnerWithFields
@@ -471,8 +471,8 @@ func (q viewerOwnerWithFields) QueryName() string {
 	return "ViewerProjectWithFields"
 }
 
-func (q viewerOwnerWithFields) Project() Project {
-	return q.Owner.Project
+func (q viewerOwnerWithFields) Project() *Project {
+	return &q.Owner.Project
 }
 
 type projectAttribute interface {
@@ -566,8 +566,8 @@ func (p ProjectField) Type() string {
 }
 
 // ProjectFields returns a project with fields. If the OwnerType is VIEWER, no login is required.
-func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (Project, error) {
-	project := Project{}
+func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (*Project, error) {
+	project := &Project{}
 	hasLimit := limit != 0
 	// the api limits batches to 100. We want to use the maximum batch size unless the user
 	// requested a lower limit.

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -983,14 +983,18 @@ func NewOwner(client api.GQLClient, userLogin, orgLogin string) (*Owner, error) 
 // NewProject creates a project based on the owner and project number
 // if number is 0 it will prompt the user to select a project interactively
 // otherwise it will make a request to get the project by number
-func NewProject(client api.GQLClient, o *Owner, number int) (*Project, error) {
+func NewProject(client api.GQLClient, o *Owner, number int, fields bool) (*Project, error) {
 	if number != 0 {
 		variables := map[string]interface{}{
 			"number":      graphql.Int(number),
-			"firstItems":  githubv4.Int(LimitMax),
+			"firstItems":  githubv4.Int(0),
 			"afterItems":  (*githubv4.String)(nil),
-			"firstFields": githubv4.Int(LimitMax),
+			"firstFields": githubv4.Int(0),
 			"afterFields": (*githubv4.String)(nil),
+		}
+
+		if fields {
+			variables["firstFields"] = githubv4.Int(LimitMax)
 		}
 		if o.Type == UserOwner {
 			var query userOwner

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -390,7 +390,6 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (Projec
 		// set the cursor to the end of the last page
 		variables["after"] = (*githubv4.String)(&cursor)
 		if o.Type == UserOwner {
-			variables["login"] = graphql.String(o.Login)
 			var query userOwnerWithItems
 			err := doQuery(client, "UserProjectWithItems", &query, variables)
 			if err != nil {
@@ -401,7 +400,6 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (Projec
 			hasNextPage = query.Owner.Project.Items.PageInfo.HasNextPage
 			cursor = query.Owner.Project.Items.PageInfo.EndCursor
 		} else if o.Type == OrgOwner {
-			variables["login"] = graphql.String(o.Login)
 			var query orgOwnerWithItems
 			err := doQuery(client, "OrgProjectWithItems", &query, variables)
 			if err != nil {
@@ -539,7 +537,6 @@ func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (Proje
 		// set the cursor to the end of the last page
 		variables["after"] = (*githubv4.String)(&cursor)
 		if o.Type == UserOwner {
-			variables["login"] = graphql.String(o.Login)
 			var query userOwnerWithFields
 			err := doQuery(client, "UserProjectWithFields", &query, variables)
 			if err != nil {
@@ -550,7 +547,6 @@ func ProjectFields(client api.GQLClient, o *Owner, number int, limit int) (Proje
 			hasNextPage = query.Owner.Project.Fields.PageInfo.HasNextPage
 			cursor = query.Owner.Project.Fields.PageInfo.EndCursor
 		} else if o.Type == OrgOwner {
-			variables["login"] = graphql.String(o.Login)
 			var query orgOwnerWithFields
 			err := doQuery(client, "OrgProjectWithFields", &query, variables)
 			if err != nil {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -341,7 +341,7 @@ func ProjectItems(client api.GQLClient, o *Owner, number int, limit int) (*Proje
 }
 
 // pager is an interface for paginating over the attributes of a Project.
-type pager[N any] interface {
+type pager[N projectAttribute] interface {
 	HasNextPage() bool
 	EndCursor() string
 	Nodes() []N

--- a/queries/queries_test.go
+++ b/queries/queries_test.go
@@ -19,9 +19,9 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"firstItems":  100,
+				"firstItems":  LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": LimitMax,
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
@@ -58,7 +58,7 @@ func TestProjectItems_DefaultLimit(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := ProjectItems(client, owner, 1, 100)
+	project, err := ProjectItems(client, owner, 1, LimitMax)
 	assert.NoError(t, err)
 	assert.Len(t, project.Items.Nodes, 3)
 }
@@ -75,7 +75,7 @@ func TestProjectItems_LowerLimit(t *testing.T) {
 			"variables": map[string]interface{}{
 				"firstItems":  2,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": LimitMax,
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
@@ -124,9 +124,9 @@ func TestProjectItems_NoLimit(t *testing.T) {
 		JSON(map[string]interface{}{
 			"query": "query UserProjectWithItems.*",
 			"variables": map[string]interface{}{
-				"firstItems":  100,
+				"firstItems":  LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": LimitMax,
 				"afterFields": nil,
 				"login":       "monalisa",
 				"number":      1,
@@ -180,7 +180,7 @@ func TestProjectFields_LowerLimit(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  LimitMax,
 				"afterItems":  nil,
 				"firstFields": 2,
 				"afterFields": nil,
@@ -232,9 +232,9 @@ func TestProjectFields_DefaultLimit(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": LimitMax,
 				"afterFields": nil,
 			},
 		}).
@@ -269,7 +269,7 @@ func TestProjectFields_DefaultLimit(t *testing.T) {
 		Login: "monalisa",
 		ID:    "user ID",
 	}
-	project, err := ProjectFields(client, owner, 1, 100)
+	project, err := ProjectFields(client, owner, 1, LimitMax)
 	assert.NoError(t, err)
 	assert.Len(t, project.Fields.Nodes, 3)
 }
@@ -286,9 +286,9 @@ func TestProjectFields_NoLimit(t *testing.T) {
 			"variables": map[string]interface{}{
 				"login":       "monalisa",
 				"number":      1,
-				"firstItems":  100,
+				"firstItems":  LimitMax,
 				"afterItems":  nil,
-				"firstFields": 100,
+				"firstFields": LimitMax,
 				"afterFields": nil,
 			},
 		}).

--- a/queries/queries_test.go
+++ b/queries/queries_test.go
@@ -1,0 +1,329 @@
+package queries
+
+import (
+	"testing"
+
+	"github.com/cli/go-gh"
+	"github.com/cli/go-gh/pkg/api"
+	"github.com/stretchr/testify/assert"
+	"gopkg.in/h2non/gock.v1"
+)
+
+func TestProjectItems_DefaultLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project items
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProjectWithItems.*",
+			"variables": map[string]interface{}{
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"items": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "issue ID",
+								},
+								{
+									"id": "pull request ID",
+								},
+								{
+									"id": "draft issue ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectItems(client, owner, 1, 100)
+	assert.NoError(t, err)
+	assert.Len(t, project.Items.Nodes, 3)
+}
+
+func TestProjectItems_LowerLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project items
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProjectWithItems.*",
+			"variables": map[string]interface{}{
+				"firstItems":  2,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"items": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "issue ID",
+								},
+								{
+									"id": "pull request ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectItems(client, owner, 1, 2)
+	assert.NoError(t, err)
+	assert.Len(t, project.Items.Nodes, 2)
+}
+
+func TestProjectItems_NoLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project items
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProjectWithItems.*",
+			"variables": map[string]interface{}{
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+				"login":       "monalisa",
+				"number":      1,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"items": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "issue ID",
+								},
+								{
+									"id": "pull request ID",
+								},
+								{
+									"id": "draft issue ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectItems(client, owner, 1, 0)
+	assert.NoError(t, err)
+	assert.Len(t, project.Items.Nodes, 3)
+}
+
+func TestProjectFields_LowerLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project fields
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 2,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"fields": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "field ID",
+								},
+								{
+									"id": "status ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectFields(client, owner, 1, 2)
+	assert.NoError(t, err)
+	assert.Len(t, project.Fields.Nodes, 2)
+}
+
+func TestProjectFields_DefaultLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project fields
+	// list project fields
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"fields": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "field ID",
+								},
+								{
+									"id": "status ID",
+								},
+								{
+									"id": "iteration ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectFields(client, owner, 1, 100)
+	assert.NoError(t, err)
+	assert.Len(t, project.Fields.Nodes, 3)
+}
+
+func TestProjectFields_NoLimit(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// list project fields
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		JSON(map[string]interface{}{
+			"query": "query UserProject.*",
+			"variables": map[string]interface{}{
+				"login":       "monalisa",
+				"number":      1,
+				"firstItems":  100,
+				"afterItems":  nil,
+				"firstFields": 100,
+				"afterFields": nil,
+			},
+		}).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"user": map[string]interface{}{
+					"projectV2": map[string]interface{}{
+						"fields": map[string]interface{}{
+							"nodes": []map[string]interface{}{
+								{
+									"id": "field ID",
+								},
+								{
+									"id": "status ID",
+								},
+								{
+									"id": "iteration ID",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	owner := &Owner{
+		Type:  "USER",
+		Login: "monalisa",
+		ID:    "user ID",
+	}
+	project, err := ProjectFields(client, owner, 1, 0)
+	assert.NoError(t, err)
+	assert.Len(t, project.Fields.Nodes, 3)
+}


### PR DESCRIPTION
Pretty large refactor to:
- remove the multiple types of `Project` structs in `queries` package, and use a single one
- avoid fetching data like fields that won't be used in JSON display
- pass pointers instead of references to avoid copying, which can be a factor when projects have a lot of items
- use generics to make fetching project attributes such as items and fields through pagination repeateable in a single place. 

In other words, these are performance and code quality changes that should not change anything from a user's perspective.

On the topic of generics: I considered making the pagination for `Projects` conform to the generic interface of `projectAttribute` and it didn't end up being worth it. the code was harder to read, mostly because Projects belong to an Owner while the attributes belong to a project. I don't think adding generics here makes a big difference to readability, it started as an exercise for myself to see what was possible, and I'm happy enough with the result that I think it's worth leaving.