### PR TITLE
item edit

### DIFF
--- a/cmd/item-edit/item_edit.go
+++ b/cmd/item-edit/item_edit.go
@@ -101,7 +101,7 @@ gh projects item-edit --id ID --project-id PROJECT_ID --text "new text"
 	editItemCmd.Flags().StringVar(&opts.projectID, "project-id", "", "ID of the project to which the field belongs to.")
 	editItemCmd.Flags().StringVar(&opts.text, "text", "", "Text value to set on the field.")
 	editItemCmd.Flags().Float32Var(&opts.number, "number", 0, "Number value to set on the field.")
-	editItemCmd.Flags().StringVar(&opts.date, "date", "", "The ISO 8601 date value to set on the field.")
+	editItemCmd.Flags().StringVar(&opts.date, "date", "", "The ISO 8601 (YYYY-MM-DD) date value to set on the field.")
 	editItemCmd.Flags().StringVar(&opts.singleSelectOptionID, "single-select-option-id", "", "ID of the single select option value to set on the field.")
 	editItemCmd.Flags().StringVar(&opts.iterationID, "iteration-id", "", "ID of the iteration value to set on the field.")
 

--- a/cmd/item-edit/item_edit_test.go
+++ b/cmd/item-edit/item_edit_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/h2non/gock.v1"
 )
 
-func TestRunItemEdit(t *testing.T) {
+func TestRunItemEdit_Draft(t *testing.T) {
 	defer gock.Off()
 	gock.Observe(gock.DumpRequest)
 
@@ -53,6 +53,261 @@ func TestRunItemEdit(t *testing.T) {
 		buf.String())
 }
 
+func TestRunItemEdit_Text(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// edit item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"text":"item text"}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"ID": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"body":       "body",
+							"title":      "title",
+							"number":     1,
+							"repository": map[string]interface{}{
+								"nameWithOwner": "my-repo",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := editItemConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: editItemOpts{
+			text:      "item text",
+			itemID:    "item_id",
+			projectID: "project_id",
+			fieldID:   "field_id",
+		},
+		client: client,
+	}
+
+	err = runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Type\tTitle\tNumber\tRepository\tID\nIssue\ttitle\t1\tmy-repo\titem_id\n",
+		buf.String())
+}
+
+func TestRunItemEdit_Number(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// edit item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"number":2}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"ID": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"body":       "body",
+							"title":      "title",
+							"number":     1,
+							"repository": map[string]interface{}{
+								"nameWithOwner": "my-repo",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := editItemConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: editItemOpts{
+			number:    2,
+			itemID:    "item_id",
+			projectID: "project_id",
+			fieldID:   "field_id",
+		},
+		client: client,
+	}
+
+	err = runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Type\tTitle\tNumber\tRepository\tID\nIssue\ttitle\t1\tmy-repo\titem_id\n",
+		buf.String())
+}
+
+func TestRunItemEdit_Date(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// edit item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"date":"2023-01-01T00:00:00Z"}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"ID": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"body":       "body",
+							"title":      "title",
+							"number":     1,
+							"repository": map[string]interface{}{
+								"nameWithOwner": "my-repo",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := editItemConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: editItemOpts{
+			date:      "2023-01-01",
+			itemID:    "item_id",
+			projectID: "project_id",
+			fieldID:   "field_id",
+		},
+		client: client,
+	}
+
+	err = runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Type\tTitle\tNumber\tRepository\tID\nIssue\ttitle\t1\tmy-repo\titem_id\n",
+		buf.String())
+}
+
+func TestRunItemEdit_SingleSelect(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// edit item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"singleSelectOptionId":"option_id"}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"ID": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"body":       "body",
+							"title":      "title",
+							"number":     1,
+							"repository": map[string]interface{}{
+								"nameWithOwner": "my-repo",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := editItemConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: editItemOpts{
+			singleSelectOptionID: "option_id",
+			itemID:               "item_id",
+			projectID:            "project_id",
+			fieldID:              "field_id",
+		},
+		client: client,
+	}
+
+	err = runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Type\tTitle\tNumber\tRepository\tID\nIssue\ttitle\t1\tmy-repo\titem_id\n",
+		buf.String())
+}
+
+func TestRunItemEdit_Iteration(t *testing.T) {
+	defer gock.Off()
+	gock.Observe(gock.DumpRequest)
+
+	// edit item
+	gock.New("https://api.github.com").
+		Post("/graphql").
+		BodyString(`{"query":"mutation UpdateItemValues.*","variables":{"input":{"projectId":"project_id","itemId":"item_id","fieldId":"field_id","value":{"iterationId":"option_id"}}}}`).
+		Reply(200).
+		JSON(map[string]interface{}{
+			"data": map[string]interface{}{
+				"updateProjectV2ItemFieldValue": map[string]interface{}{
+					"projectV2Item": map[string]interface{}{
+						"ID": "item_id",
+						"content": map[string]interface{}{
+							"__typename": "Issue",
+							"body":       "body",
+							"title":      "title",
+							"number":     1,
+							"repository": map[string]interface{}{
+								"nameWithOwner": "my-repo",
+							},
+						},
+					},
+				},
+			},
+		})
+
+	client, err := gh.GQLClient(&api.ClientOptions{AuthToken: "token"})
+	assert.NoError(t, err)
+
+	buf := bytes.Buffer{}
+	config := editItemConfig{
+		tp: tableprinter.New(&buf, false, 0),
+		opts: editItemOpts{
+			iterationID: "option_id",
+			itemID:      "item_id",
+			projectID:   "project_id",
+			fieldID:     "field_id",
+		},
+		client: client,
+	}
+
+	err = runEditItem(config)
+	assert.NoError(t, err)
+	assert.Equal(
+		t,
+		"Type\tTitle\tNumber\tRepository\tID\nIssue\ttitle\t1\tmy-repo\titem_id\n",
+		buf.String())
+}
+
 func TestRunItemEdit_NoChanges(t *testing.T) {
 	defer gock.Off()
 	gock.Observe(gock.DumpRequest)
@@ -75,7 +330,7 @@ func TestRunItemEdit_NoChanges(t *testing.T) {
 		buf.String())
 }
 
-func TestRunItemEdit_InavlidID(t *testing.T) {
+func TestRunItemEdit_InvalidID(t *testing.T) {
 	defer gock.Off()
 	gock.Observe(gock.DumpRequest)
 


### PR DESCRIPTION
Closes https://github.com/github/gh-projects/issues/84

Builds on the existing item-edit command to allow updating item fields with https://docs.github.com/en/graphql/reference/mutations#updateprojectv2itemfieldvalue