### PR TITLE
display single select options in json format

### DIFF
--- a/cmd/field-create/field_create.go
+++ b/cmd/field-create/field_create.go
@@ -145,10 +145,11 @@ func createFieldArgs(config createFieldConfig) (*createProjectV2FieldMutation, m
 	}
 
 	if len(config.opts.singleSelectOptions) != 0 {
-		opts := make([]githubv4.ProjectV2SingleSelectFieldOptionInput, len(config.opts.singleSelectOptions))
+		opts := make([]githubv4.ProjectV2SingleSelectFieldOptionInput, 0)
 		for _, opt := range config.opts.singleSelectOptions {
 			opts = append(opts, githubv4.ProjectV2SingleSelectFieldOptionInput{
-				Name: githubv4.String(opt),
+				Name:  githubv4.String(opt),
+				Color: githubv4.ProjectV2SingleSelectFieldOptionColor("GRAY"),
 			})
 		}
 		input.SingleSelectOptions = &opts

--- a/format/json.go
+++ b/format/json.go
@@ -104,11 +104,24 @@ type projectJSON struct {
 
 // JSONProjectField serializes a ProjectField to JSON.
 func JSONProjectField(field queries.ProjectField) ([]byte, error) {
-	return json.Marshal(projectFieldJSON{
+	val := projectFieldJSON{
 		ID:   field.ID(),
 		Name: field.Name(),
 		Type: field.Type(),
-	})
+	}
+
+	if len(field.Options()) != 0 {
+		for _, o := range field.Options() {
+			val.Options = append(val.Options, struct {
+				Name string `json:"name"`
+				ID   string `json:"id"`
+			}{
+				Name: o.Name,
+				ID:   o.ID,
+			})
+		}
+	}
+	return json.Marshal(val)
 }
 
 // JSONProjectFields serializes a slice of ProjectFields to JSON.
@@ -116,11 +129,23 @@ func JSONProjectField(field queries.ProjectField) ([]byte, error) {
 func JSONProjectFields(project *queries.Project) ([]byte, error) {
 	var result []projectFieldJSON
 	for _, f := range project.Fields.Nodes {
-		result = append(result, projectFieldJSON{
+		val := projectFieldJSON{
 			ID:   f.ID(),
 			Name: f.Name(),
 			Type: f.Type(),
-		})
+		}
+		if len(f.Options()) != 0 {
+			for _, o := range f.Options() {
+				val.Options = append(val.Options, struct {
+					Name string `json:"name"`
+					ID   string `json:"id"`
+				}{
+					Name: o.Name,
+					ID:   o.ID,
+				})
+			}
+		}
+		result = append(result, val)
 	}
 
 	return json.Marshal(struct {
@@ -133,9 +158,13 @@ func JSONProjectFields(project *queries.Project) ([]byte, error) {
 }
 
 type projectFieldJSON struct {
-	ID   string `json:"id"`
-	Name string `json:"name"`
-	Type string `json:"type"`
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Type    string `json:"type"`
+	Options []struct {
+		Name string `json:"name"`
+		ID   string `json:"id"`
+	} `json:"options,omitempty"`
 }
 
 // JSONProjectItem serializes a ProjectItem to JSON.

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -102,11 +102,24 @@ func TestJSONProjectField_SingleSelectType(t *testing.T) {
 	field.TypeName = "ProjectV2SingleSelectField"
 	field.SingleSelectField.ID = "123"
 	field.SingleSelectField.Name = "name"
+	field.SingleSelectField.Options = []struct {
+		ID   string
+		Name string
+	}{
+		{
+			ID:   "123",
+			Name: "name",
+		},
+		{
+			ID:   "456",
+			Name: "name2",
+		},
+	}
 
 	b, err := JSONProjectField(field)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2SingleSelectField"}`, string(b))
+	assert.Equal(t, `{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"name":"name","id":"123"},{"name":"name2","id":"456"}]}`, string(b))
 }
 
 func TestJSONProjectField_ProjectV2IterationField(t *testing.T) {
@@ -127,20 +140,38 @@ func TestJSONProjectFields(t *testing.T) {
 	field.Field.ID = "123"
 	field.Field.Name = "name"
 
+	field2 := queries.ProjectField{}
+	field2.TypeName = "ProjectV2SingleSelectField"
+	field2.SingleSelectField.ID = "123"
+	field2.SingleSelectField.Name = "name"
+	field2.SingleSelectField.Options = []struct {
+		ID   string
+		Name string
+	}{
+		{
+			ID:   "123",
+			Name: "name",
+		},
+		{
+			ID:   "456",
+			Name: "name2",
+		},
+	}
+
 	p := &queries.Project{
 		Fields: struct {
 			TotalCount int
 			Nodes      []queries.ProjectField
 			PageInfo   queries.PageInfo
 		}{
-			Nodes:      []queries.ProjectField{field},
+			Nodes:      []queries.ProjectField{field, field2},
 			TotalCount: 5,
 		},
 	}
 	b, err := JSONProjectFields(p)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"fields":[{"id":"123","name":"name","type":"ProjectV2Field"}],"totalCount":5}`, string(b))
+	assert.Equal(t, `{"fields":[{"id":"123","name":"name","type":"ProjectV2Field"},{"id":"123","name":"name","type":"ProjectV2SingleSelectField","options":[{"name":"name","id":"123"},{"name":"name2","id":"456"}]}],"totalCount":5}`, string(b))
 }
 
 func TestJSONProjectItem_DraftIssue(t *testing.T) {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -512,6 +512,10 @@ type ProjectField struct {
 		ID       string
 		Name     string
 		DataType string
+		Options  []struct {
+			ID   string
+			Name string
+		}
 	} `graphql:"... on ProjectV2SingleSelectField"`
 }
 
@@ -542,6 +546,25 @@ func (p ProjectField) Name() string {
 // Type is the typename of the project field.
 func (p ProjectField) Type() string {
 	return p.TypeName
+}
+
+type SingleSelectOptions struct {
+	ID   string
+	Name string
+}
+
+func (p ProjectField) Options() []SingleSelectOptions {
+	if p.TypeName == "ProjectV2SingleSelectField" {
+		var options []SingleSelectOptions
+		for _, o := range p.SingleSelectField.Options {
+			options = append(options, SingleSelectOptions{
+				ID:   o.ID,
+				Name: o.Name,
+			})
+		}
+		return options
+	}
+	return nil
 }
 
 // ProjectFields returns a project with fields. If the OwnerType is VIEWER, no login is required.


### PR DESCRIPTION
When using `--format=json` for fields, display the name and id for fields.

Fixes a bug where create-field was sending empty data with single select options.

Set the default color for single select options to gray, as this is a required field by the API.