### PR TITLE
show the item url when one exists

### DIFF
--- a/format/json.go
+++ b/format/json.go
@@ -167,6 +167,7 @@ func JSONProjectItem(item queries.ProjectItem) ([]byte, error) {
 		Title: item.Title(),
 		Body:  item.Body(),
 		Type:  item.Type(),
+		URL:   item.URL(),
 	})
 }
 
@@ -175,6 +176,7 @@ type projectItemJSON struct {
 	Title string `json:"title"`
 	Body  string `json:"body"`
 	Type  string `json:"type"`
+	URL   string `json:"url,omitempty"`
 }
 
 // JSONProjectDraftIssue serializes a DraftIssue to JSON.
@@ -207,9 +209,9 @@ func projectItemContent(p queries.ProjectItem) any {
 			Body  string `json:"body"`
 			Title string `json:"title"`
 		}{
-			Type:  p.Content.TypeName,
-			Body:  p.Content.DraftIssue.Body,
-			Title: p.Content.DraftIssue.Title,
+			Type:  p.Type(),
+			Body:  p.Body(),
+			Title: p.Title(),
 		}
 	case "Issue":
 		return struct {
@@ -218,12 +220,14 @@ func projectItemContent(p queries.ProjectItem) any {
 			Title      string `json:"title"`
 			Number     int    `json:"number"`
 			Repository string `json:"repository"`
+			URL        string `json:"url"`
 		}{
-			Type:       p.Content.TypeName,
-			Body:       p.Content.Issue.Body,
-			Title:      p.Content.Issue.Title,
-			Number:     p.Content.Issue.Number,
-			Repository: p.Content.Issue.Repository.NameWithOwner,
+			Type:       p.Type(),
+			Body:       p.Body(),
+			Title:      p.Title(),
+			Number:     p.Number(),
+			Repository: p.Repo(),
+			URL:        p.URL(),
 		}
 	case "PullRequest":
 		return struct {
@@ -232,12 +236,14 @@ func projectItemContent(p queries.ProjectItem) any {
 			Title      string `json:"title"`
 			Number     int    `json:"number"`
 			Repository string `json:"repository"`
+			URL        string `json:"url"`
 		}{
-			Type:       p.Content.TypeName,
-			Body:       p.Content.PullRequest.Body,
-			Title:      p.Content.PullRequest.Title,
-			Number:     p.Content.PullRequest.Number,
-			Repository: p.Content.PullRequest.Repository.NameWithOwner,
+			Type:       p.Type(),
+			Body:       p.Body(),
+			Title:      p.Title(),
+			Number:     p.Number(),
+			Repository: p.Repo(),
+			URL:        p.URL(),
 		}
 	}
 

--- a/format/json_test.go
+++ b/format/json_test.go
@@ -187,11 +187,26 @@ func TestJSONProjectItem_Issue(t *testing.T) {
 	item.Id = "123"
 	item.Content.Issue.Title = "title"
 	item.Content.Issue.Body = "a body"
+	item.Content.Issue.URL = "a-url"
 
 	b, err := JSONProjectItem(item)
 	assert.NoError(t, err)
 
-	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"Issue"}`, string(b))
+	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"Issue","url":"a-url"}`, string(b))
+}
+
+func TestJSONProjectItem_PullRequest(t *testing.T) {
+	item := queries.ProjectItem{}
+	item.Content.TypeName = "PullRequest"
+	item.Id = "123"
+	item.Content.PullRequest.Title = "title"
+	item.Content.PullRequest.Body = "a body"
+	item.Content.PullRequest.URL = "a-url"
+
+	b, err := JSONProjectItem(item)
+	assert.NoError(t, err)
+
+	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"PullRequest","url":"a-url"}`, string(b))
 }
 
 func TestJSONProjectDetailedItems(t *testing.T) {
@@ -206,6 +221,7 @@ func TestJSONProjectDetailedItems(t *testing.T) {
 					Title:  "Issue title",
 					Body:   "a body",
 					Number: 1,
+					URL:    "issue-url",
 					Repository: struct {
 						NameWithOwner string
 					}{
@@ -222,6 +238,7 @@ func TestJSONProjectDetailedItems(t *testing.T) {
 					Title:  "Pull Request title",
 					Body:   "a body",
 					Number: 2,
+					URL:    "pr-url",
 					Repository: struct {
 						NameWithOwner string
 					}{
@@ -246,21 +263,8 @@ func TestJSONProjectDetailedItems(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(
 		t,
-		`{"items":[{"content":{"type":"Issue","body":"a body","title":"Issue title","number":1,"repository":"cli/go-gh"},"id":"issueId"},{"content":{"type":"PullRequest","body":"a body","title":"Pull Request title","number":2,"repository":"cli/go-gh"},"id":"pullRequestId"},{"content":{"type":"DraftIssue","body":"a body","title":"Pull Request title"},"id":"draftIssueId"}],"totalCount":5}`,
+		`{"items":[{"content":{"type":"Issue","body":"a body","title":"Issue title","number":1,"repository":"cli/go-gh","url":"issue-url"},"id":"issueId"},{"content":{"type":"PullRequest","body":"a body","title":"Pull Request title","number":2,"repository":"cli/go-gh","url":"pr-url"},"id":"pullRequestId"},{"content":{"type":"DraftIssue","body":"a body","title":"Pull Request title"},"id":"draftIssueId"}],"totalCount":5}`,
 		string(out))
-}
-
-func TestJSONProjectItem_PullRequest(t *testing.T) {
-	item := queries.ProjectItem{}
-	item.Content.TypeName = "PullRequest"
-	item.Id = "123"
-	item.Content.PullRequest.Title = "title"
-	item.Content.PullRequest.Body = "a body"
-
-	b, err := JSONProjectItem(item)
-	assert.NoError(t, err)
-
-	assert.Equal(t, `{"id":"123","title":"title","body":"a body","type":"PullRequest"}`, string(b))
 }
 
 func TestJSONProjectDraftIssue(t *testing.T) {

--- a/queries/queries.go
+++ b/queries/queries.go
@@ -223,6 +223,7 @@ type PullRequest struct {
 	Body       string
 	Title      string
 	Number     int
+	URL        string
 	Repository struct {
 		NameWithOwner string
 	}
@@ -232,6 +233,7 @@ type Issue struct {
 	Body       string
 	Title      string
 	Number     int
+	URL        string
 	Repository struct {
 		NameWithOwner string
 	}
@@ -292,6 +294,17 @@ func (p ProjectItem) Repo() string {
 		return p.Content.Issue.Repository.NameWithOwner
 	case "PullRequest":
 		return p.Content.PullRequest.Repository.NameWithOwner
+	}
+	return ""
+}
+
+// URL is the URL of the project item. Note the draft issues do not have URLs
+func (p ProjectItem) URL() string {
+	switch p.Content.TypeName {
+	case "Issue":
+		return p.Content.Issue.URL
+	case "PullRequest":
+		return p.Content.PullRequest.URL
 	}
 	return ""
 }


### PR DESCRIPTION
Show the item url in JSON output for Issues and Pull Requests. Note that this value could be constructed from the repo and number, but the host would be unknown, and would be incorrect for non-github.com hosts.